### PR TITLE
feat(terraform/linode): expose optional secrets as Terraform variables

### DIFF
--- a/terraform/linode/helm.tf
+++ b/terraform/linode/helm.tf
@@ -135,6 +135,26 @@ resource "helm_release" "omcsi" {
     }
   }
 
+  # Discord alerts (auto-enabled when webhook URL is provided)
+  dynamic "set" {
+    for_each = var.discord_webhook_url != "" ? [1] : []
+    content {
+      name  = "alertManager.env.DISCORD_ENABLED"
+      value = "true"
+    }
+  }
+
+  set_sensitive {
+    name  = "secrets.discordWebhookUrl"
+    value = var.discord_webhook_url
+  }
+
+  # Plugin hot-deploy token
+  set_sensitive {
+    name  = "secrets.deployAuthToken"
+    value = var.deploy_auth_token
+  }
+
   # Agent-manager (optional)
   set {
     name  = "agentManager.enabled"

--- a/terraform/linode/helm.tf
+++ b/terraform/linode/helm.tf
@@ -144,15 +144,21 @@ resource "helm_release" "omcsi" {
     }
   }
 
-  set_sensitive {
-    name  = "secrets.discordWebhookUrl"
-    value = var.discord_webhook_url
+  dynamic "set_sensitive" {
+    for_each = var.discord_webhook_url != "" ? [1] : []
+    content {
+      name  = "secrets.discordWebhookUrl"
+      value = var.discord_webhook_url
+    }
   }
 
   # Plugin hot-deploy token
-  set_sensitive {
-    name  = "secrets.deployAuthToken"
-    value = var.deploy_auth_token
+  dynamic "set_sensitive" {
+    for_each = var.deploy_auth_token != "" ? [1] : []
+    content {
+      name  = "secrets.deployAuthToken"
+      value = var.deploy_auth_token
+    }
   }
 
   # Agent-manager (optional)

--- a/terraform/linode/outputs.tf
+++ b/terraform/linode/outputs.tf
@@ -34,5 +34,5 @@ output "helm_release_status" {
 
 output "get_nginx_ip_command" {
   description = "Run after apply to retrieve the public nginx LoadBalancer IP (server address and dashboard endpoint)."
-  value       = "kubectl get svc -n ${var.helm_namespace} --kubeconfig ${local_sensitive_file.kubeconfig.filename}"
+  value       = "kubectl get svc -n ${var.helm_namespace} -l app.kubernetes.io/component=nginx --kubeconfig ${local_sensitive_file.kubeconfig.filename} -o jsonpath='{range .items[*]}{.metadata.name}{\"\\t\"}{.status.loadBalancer.ingress[0].ip}{.status.loadBalancer.ingress[0].hostname}{\"\\n\"}{end}'"
 }

--- a/terraform/linode/outputs.tf
+++ b/terraform/linode/outputs.tf
@@ -31,3 +31,8 @@ output "helm_release_status" {
   description = "Status of the OMCSI Helm release."
   value       = helm_release.omcsi.status
 }
+
+output "get_nginx_ip_command" {
+  description = "Run after apply to retrieve the public nginx LoadBalancer IP (server address and dashboard endpoint)."
+  value       = "kubectl get svc -n ${var.helm_namespace} --kubeconfig ${local_sensitive_file.kubeconfig.filename}"
+}

--- a/terraform/linode/outputs.tf
+++ b/terraform/linode/outputs.tf
@@ -33,6 +33,6 @@ output "helm_release_status" {
 }
 
 output "get_nginx_ip_command" {
-  description = "Run after apply to retrieve the public nginx LoadBalancer IP (server address and dashboard endpoint)."
+  description = "Run after apply to retrieve the nginx LoadBalancer endpoint as tab-separated columns: service name, ingress IP, ingress hostname."
   value       = "kubectl get svc -n ${var.helm_namespace} -l app.kubernetes.io/component=nginx --kubeconfig ${local_sensitive_file.kubeconfig.filename} -o jsonpath='{range .items[*]}{.metadata.name}{\"\\t\"}{.status.loadBalancer.ingress[0].ip}{\"\\t\"}{.status.loadBalancer.ingress[0].hostname}{\"\\n\"}{end}'"
 }

--- a/terraform/linode/outputs.tf
+++ b/terraform/linode/outputs.tf
@@ -34,5 +34,5 @@ output "helm_release_status" {
 
 output "get_nginx_ip_command" {
   description = "Run after apply to retrieve the public nginx LoadBalancer IP (server address and dashboard endpoint)."
-  value       = "kubectl get svc -n ${var.helm_namespace} -l app.kubernetes.io/component=nginx --kubeconfig ${local_sensitive_file.kubeconfig.filename} -o jsonpath='{range .items[*]}{.metadata.name}{\"\\t\"}{.status.loadBalancer.ingress[0].ip}{.status.loadBalancer.ingress[0].hostname}{\"\\n\"}{end}'"
+  value       = "kubectl get svc -n ${var.helm_namespace} -l app.kubernetes.io/component=nginx --kubeconfig ${local_sensitive_file.kubeconfig.filename} -o jsonpath='{range .items[*]}{.metadata.name}{\"\\t\"}{.status.loadBalancer.ingress[0].ip}{\"\\t\"}{.status.loadBalancer.ingress[0].hostname}{\"\\n\"}{end}'"
 }

--- a/terraform/linode/terraform.tfvars.example
+++ b/terraform/linode/terraform.tfvars.example
@@ -32,6 +32,13 @@ admin_password = "strongpassword"
 # if your cluster uses a different StorageClass.
 # storage_class = "linode-block-storage-retain"
 
+# Optional: Discord alerts (alert-manager)
+# Setting discord_webhook_url automatically enables Discord in alert-manager.
+# discord_webhook_url = "https://discord.com/api/webhooks/..."
+
+# Optional: plugin hot-deploy bearer token (POST /api/plugins/deploy)
+# deploy_auth_token = "your-secret-token"
+
 # Optional: agent-manager (Discord AI bot)
 # agent_manager_enabled    = true
 # agent_discord_bot_token  = "BOT_TOKEN"
@@ -39,4 +46,6 @@ admin_password = "strongpassword"
 # agent_anthropic_api_key  = "API_KEY"
 
 # Optional: custom Helm values file
-# helm_values_file = "my-values.yaml"
+# Use this to override any Helm chart value not exposed as a Terraform variable
+# (e.g., MOTD, operator UUID, resource limits, TLS settings).
+# helm_values_file = "/absolute/path/to/my-values.yaml"

--- a/terraform/linode/variables.tf
+++ b/terraform/linode/variables.tf
@@ -115,7 +115,7 @@ variable "discord_webhook_url" {
 }
 
 variable "deploy_auth_token" {
-  description = "Bearer token for the plugin hot-deploy endpoint (POST /api/plugins/deploy). Leave empty to disable authenticated hot-deploy."
+  description = "Bearer token for the plugin hot-deploy endpoint (POST /api/plugins/deploy). Leave empty to disable the deploy endpoint (all deploy requests are rejected)."
   type        = string
   sensitive   = true
   default     = ""

--- a/terraform/linode/variables.tf
+++ b/terraform/linode/variables.tf
@@ -104,6 +104,24 @@ variable "helm_values_file" {
 }
 
 # =============================================================================
+# Optional: notifications and plugin deployment
+# =============================================================================
+
+variable "discord_webhook_url" {
+  description = "Discord webhook URL for alert-manager notifications (server start/stop/crash/backup events). When set, Discord alerts are automatically enabled."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "deploy_auth_token" {
+  description = "Bearer token for the plugin hot-deploy endpoint (POST /api/plugins/deploy). Leave empty to disable authenticated hot-deploy."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+# =============================================================================
 # Optional: agent-manager
 # =============================================================================
 


### PR DESCRIPTION
## Summary

- Add `discord_webhook_url` and `deploy_auth_token` as optional Terraform variables in the Linode module, wired into the Helm chart via `set_sensitive` blocks
- Setting `discord_webhook_url` automatically enables Discord in `alert-manager` (no separate toggle needed)
- Add `get_nginx_ip_command` output so deployers know the server's public address immediately after `apply`
- Document `discord_webhook_url`, `deploy_auth_token`, and `helm_values_file` usage in `terraform.tfvars.example`

## Motivation

Previously these secrets had no Terraform variable, forcing deployers to use a custom `helm_values_file` workaround just to set a Discord webhook or deploy token. This makes them first-class variables alongside the existing required secrets.

## Test plan

- [ ] `terraform plan` shows no unexpected changes on an existing deployment
- [ ] Setting `TF_VAR_discord_webhook_url` triggers `alertManager.env.DISCORD_ENABLED=true` in the Helm release
- [ ] `terraform output get_nginx_ip_command` prints a valid `kubectl get svc` command after apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_