### PR TITLE
feat: add Docker publish workflow for all OMCSI images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,6 +7,11 @@ on:
       - 'Dockerfile'
       - 'minecraft-wrapper/**'
       - 'resources/**'
+      - 'web-app/**'
+      - 'nginx/**'
+      - 'alert-manager/**'
+      - 'backup-manager/**'
+      - 'agent-manager/**'
       - '.github/workflows/docker-publish.yml'
   workflow_dispatch:
     inputs:
@@ -21,6 +26,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   build-open-mc-server:
@@ -35,12 +41,19 @@ jobs:
         id: mc_version
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "version=${{ github.event.inputs.minecraft_version }}" >> "$GITHUB_OUTPUT"
+            raw_version="${{ github.event.inputs.minecraft_version }}"
+            # Allow only digits, dots, and hyphens (e.g. "26.1", "1.21.4", "1.21-pre1")
+            if ! echo "${raw_version}" | grep -qE '^[0-9][0-9a-zA-Z.-]*$'; then
+              echo "::error::Invalid minecraft_version input: '${raw_version}'. Only alphanumeric characters, dots, and hyphens are allowed."
+              exit 1
+            fi
+            version="${raw_version}"
           else
             # Extract default from Dockerfile ARG
             version=$(grep 'ARG MINECRAFT_VERSION=' Dockerfile | head -1 | cut -d= -f2)
-            echo "version=${version}" >> "$GITHUB_OUTPUT"
           fi
+          # Version is validated above; simple assignment is safe here
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/docker-publish.yml` that builds and pushes all OMCSI Docker Hub images when relevant files change on `main`
- `open-mc-server` is built via a multi-stage Dockerfile that runs BuildTools to compile Spigot — the Minecraft version is read from the Dockerfile's `ARG MINECRAFT_VERSION` default (currently `26.1`)
- All five supporting images (`webapp`, `nginx`, `alert-manager`, `backup-manager`, `agent-manager`) are built in parallel via a matrix job
- Manual `workflow_dispatch` trigger supports specifying a custom Minecraft version and toggling the Docker Hub push (useful for testing the build without publishing)
- GitHub Actions build cache (`type=gha`) is used to avoid recompiling Spigot on every run

## Setup required

Add the following secrets to the repository before this workflow can push to Docker Hub:

| Secret | Value |
|---|---|
| `DOCKERHUB_USERNAME` | Docker Hub username (`dmccoystephenson`) |
| `DOCKERHUB_TOKEN` | Docker Hub access token (generate at hub.docker.com → Account Settings → Security) |

## Why now

The `latest` image on Docker Hub was built with Spigot 1.21.10. The Dockerfile defaults to 26.1, but no CI existed to rebuild and push the image when the version changes. This workflow closes that gap.

## Test plan

- [ ] Add `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` to repository secrets
- [ ] Trigger manually via `workflow_dispatch` with `push_images: false` to validate the build succeeds without publishing
- [ ] Trigger with `push_images: true` to publish the 26.1 image to Docker Hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_