### PR TITLE
feat(terraform): expose optional secrets in existing-cluster and aws modules

### DIFF
--- a/terraform/aws/helm.tf
+++ b/terraform/aws/helm.tf
@@ -143,6 +143,26 @@ resource "helm_release" "omcsi" {
     }
   }
 
+  # Discord alerts (auto-enabled when webhook URL is provided)
+  dynamic "set" {
+    for_each = var.discord_webhook_url != "" ? [1] : []
+    content {
+      name  = "alertManager.env.DISCORD_ENABLED"
+      value = "true"
+    }
+  }
+
+  set_sensitive {
+    name  = "secrets.discordWebhookUrl"
+    value = var.discord_webhook_url
+  }
+
+  # Plugin hot-deploy token
+  set_sensitive {
+    name  = "secrets.deployAuthToken"
+    value = var.deploy_auth_token
+  }
+
   # Agent-manager (optional)
   set {
     name  = "agentManager.enabled"

--- a/terraform/aws/terraform.tfvars.example
+++ b/terraform/aws/terraform.tfvars.example
@@ -37,6 +37,13 @@ admin_password = "strongpassword"
 # cluster uses a different StorageClass (e.g., "gp3", "io1").
 # storage_class = "gp2"
 
+# Optional: Discord alerts (alert-manager)
+# Setting discord_webhook_url automatically enables Discord in alert-manager.
+# discord_webhook_url = "https://discord.com/api/webhooks/..."
+
+# Optional: plugin hot-deploy bearer token (POST /api/plugins/deploy)
+# deploy_auth_token = "your-secret-token"
+
 # Optional: agent-manager (Discord AI bot)
 # agent_manager_enabled    = true
 # agent_discord_bot_token  = "BOT_TOKEN"
@@ -44,4 +51,6 @@ admin_password = "strongpassword"
 # agent_anthropic_api_key  = "API_KEY"
 
 # Optional: custom Helm values file
-# helm_values_file = "my-values.yaml"
+# Use this to override any Helm chart value not exposed as a Terraform variable
+# (e.g., MOTD, operator UUID, resource limits, TLS settings).
+# helm_values_file = "/absolute/path/to/my-values.yaml"

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -102,6 +102,24 @@ variable "helm_values_file" {
 }
 
 # =============================================================================
+# Optional: notifications and plugin deployment
+# =============================================================================
+
+variable "discord_webhook_url" {
+  description = "Discord webhook URL for alert-manager notifications (server start/stop/crash/backup events). When set, Discord alerts are automatically enabled."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "deploy_auth_token" {
+  description = "Bearer token for the plugin hot-deploy endpoint (POST /api/plugins/deploy). Leave empty to disable the deploy endpoint (all deploy requests are rejected)."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+# =============================================================================
 # Optional: agent-manager
 # =============================================================================
 

--- a/terraform/existing-cluster/main.tf
+++ b/terraform/existing-cluster/main.tf
@@ -145,6 +145,26 @@ resource "helm_release" "omcsi" {
     }
   }
 
+  # Discord alerts (auto-enabled when webhook URL is provided)
+  dynamic "set" {
+    for_each = var.discord_webhook_url != "" ? [1] : []
+    content {
+      name  = "alertManager.env.DISCORD_ENABLED"
+      value = "true"
+    }
+  }
+
+  set_sensitive {
+    name  = "secrets.discordWebhookUrl"
+    value = var.discord_webhook_url
+  }
+
+  # Plugin hot-deploy token
+  set_sensitive {
+    name  = "secrets.deployAuthToken"
+    value = var.deploy_auth_token
+  }
+
   # Agent-manager (optional)
   set {
     name  = "agentManager.enabled"

--- a/terraform/existing-cluster/terraform.tfvars.example
+++ b/terraform/existing-cluster/terraform.tfvars.example
@@ -26,6 +26,13 @@ admin_password = "strongpassword"
 # if your cluster requires a specific class.
 # storage_class = ""
 
+# Optional: Discord alerts (alert-manager)
+# Setting discord_webhook_url automatically enables Discord in alert-manager.
+# discord_webhook_url = "https://discord.com/api/webhooks/..."
+
+# Optional: plugin hot-deploy bearer token (POST /api/plugins/deploy)
+# deploy_auth_token = "your-secret-token"
+
 # Optional: agent-manager (Discord AI bot)
 # agent_manager_enabled    = true
 # agent_discord_bot_token  = "BOT_TOKEN"
@@ -33,4 +40,6 @@ admin_password = "strongpassword"
 # agent_anthropic_api_key  = "API_KEY"
 
 # Optional: custom Helm values file
-# helm_values_file = "my-values.yaml"
+# Use this to override any Helm chart value not exposed as a Terraform variable
+# (e.g., MOTD, operator UUID, resource limits, TLS settings).
+# helm_values_file = "/absolute/path/to/my-values.yaml"

--- a/terraform/existing-cluster/variables.tf
+++ b/terraform/existing-cluster/variables.tf
@@ -66,6 +66,24 @@ variable "helm_values_file" {
 }
 
 # =============================================================================
+# Optional: notifications and plugin deployment
+# =============================================================================
+
+variable "discord_webhook_url" {
+  description = "Discord webhook URL for alert-manager notifications (server start/stop/crash/backup events). When set, Discord alerts are automatically enabled."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "deploy_auth_token" {
+  description = "Bearer token for the plugin hot-deploy endpoint (POST /api/plugins/deploy). Leave empty to disable the deploy endpoint (all deploy requests are rejected)."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+# =============================================================================
 # Optional: agent-manager
 # =============================================================================
 


### PR DESCRIPTION
## Summary

- Adds `discord_webhook_url` and `deploy_auth_token` variables to both the `existing-cluster` and `aws` Terraform modules, matching the variables already added to `linode` in #133
- Wires them into Helm via `set_sensitive` blocks with the same auto-enable behaviour (setting `discord_webhook_url` flips `alertManager.env.DISCORD_ENABLED=true`)
- Updates `terraform.tfvars.example` in both modules to document the new optional variables and clarify `helm_values_file` usage

## Why

All three Terraform deployment paths (Linode, AWS, existing cluster) should expose the same set of secrets. Before this change, deployers on AWS or an existing cluster had no native Terraform path to configure Discord alerts or the hot-deploy token without a custom values file.

## Test plan

- [ ] `terraform fmt -check` passes on both modules (CI validates this)
- [ ] `terraform validate` passes on both modules (CI validates this)
- [ ] Setting `TF_VAR_discord_webhook_url` with either module enables Discord in the deployed alert-manager

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_