### PR TITLE
feat(terraform): add minecraft_service_type variable to all modules

### DIFF
--- a/terraform/aws/helm.tf
+++ b/terraform/aws/helm.tf
@@ -73,6 +73,12 @@ resource "helm_release" "omcsi" {
     value = var.admin_password
   }
 
+  # Minecraft service type
+  set {
+    name  = "minecraftWrapper.service.type"
+    value = var.minecraft_service_type
+  }
+
   # Storage class for all PVCs
   set {
     name  = "persistence.mcserver.storageClass"

--- a/terraform/aws/terraform.tfvars.example
+++ b/terraform/aws/terraform.tfvars.example
@@ -44,6 +44,10 @@ admin_password = "strongpassword"
 # Optional: plugin hot-deploy bearer token (POST /api/plugins/deploy)
 # deploy_auth_token = "your-secret-token"
 
+# Minecraft service type — 'LoadBalancer' gives a dedicated public IP on port 25565
+# (recommended for production). 'NodePort' exposes via a high port on each node.
+# minecraft_service_type = "LoadBalancer"
+
 # Optional: agent-manager (Discord AI bot)
 # agent_manager_enabled    = true
 # agent_discord_bot_token  = "BOT_TOKEN"

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -95,6 +95,17 @@ variable "storage_class" {
   default     = "gp2"
 }
 
+variable "minecraft_service_type" {
+  description = "Kubernetes Service type for the Minecraft game port (25565). Use 'LoadBalancer' for a dedicated public IP on port 25565, or 'NodePort' to expose via a high-numbered port on each node."
+  type        = string
+  default     = "NodePort"
+
+  validation {
+    condition     = contains(["NodePort", "LoadBalancer"], var.minecraft_service_type)
+    error_message = "minecraft_service_type must be 'NodePort' or 'LoadBalancer'."
+  }
+}
+
 variable "helm_values_file" {
   description = "Optional path to a custom Helm values file to merge. Leave empty to use defaults."
   type        = string

--- a/terraform/existing-cluster/main.tf
+++ b/terraform/existing-cluster/main.tf
@@ -63,6 +63,12 @@ resource "helm_release" "omcsi" {
     value = var.admin_password
   }
 
+  # Minecraft service type
+  set {
+    name  = "minecraftWrapper.service.type"
+    value = var.minecraft_service_type
+  }
+
   # Storage class for all PVCs (only when explicitly set)
   dynamic "set" {
     for_each = local.use_storage_class

--- a/terraform/existing-cluster/terraform.tfvars.example
+++ b/terraform/existing-cluster/terraform.tfvars.example
@@ -33,6 +33,10 @@ admin_password = "strongpassword"
 # Optional: plugin hot-deploy bearer token (POST /api/plugins/deploy)
 # deploy_auth_token = "your-secret-token"
 
+# Minecraft service type — 'LoadBalancer' gives a dedicated public IP on port 25565
+# (recommended for production). 'NodePort' exposes via a high port on each node.
+# minecraft_service_type = "LoadBalancer"
+
 # Optional: agent-manager (Discord AI bot)
 # agent_manager_enabled    = true
 # agent_discord_bot_token  = "BOT_TOKEN"

--- a/terraform/existing-cluster/variables.tf
+++ b/terraform/existing-cluster/variables.tf
@@ -59,6 +59,17 @@ variable "storage_class" {
   default     = ""
 }
 
+variable "minecraft_service_type" {
+  description = "Kubernetes Service type for the Minecraft game port (25565). Use 'LoadBalancer' for a dedicated public IP on port 25565, or 'NodePort' to expose via a high-numbered port on each node."
+  type        = string
+  default     = "NodePort"
+
+  validation {
+    condition     = contains(["NodePort", "LoadBalancer"], var.minecraft_service_type)
+    error_message = "minecraft_service_type must be 'NodePort' or 'LoadBalancer'."
+  }
+}
+
 variable "helm_values_file" {
   description = "Optional path to a custom Helm values file to merge. Leave empty to use defaults."
   type        = string

--- a/terraform/linode/helm.tf
+++ b/terraform/linode/helm.tf
@@ -65,6 +65,12 @@ resource "helm_release" "omcsi" {
     value = var.admin_password
   }
 
+  # Minecraft service type
+  set {
+    name  = "minecraftWrapper.service.type"
+    value = var.minecraft_service_type
+  }
+
   # Storage class for all PVCs
   set {
     name  = "persistence.mcserver.storageClass"

--- a/terraform/linode/terraform.tfvars.example
+++ b/terraform/linode/terraform.tfvars.example
@@ -39,6 +39,10 @@ admin_password = "strongpassword"
 # Optional: plugin hot-deploy bearer token (POST /api/plugins/deploy)
 # deploy_auth_token = "your-secret-token"
 
+# Minecraft service type — 'LoadBalancer' gives a dedicated public IP on port 25565
+# (recommended for production). 'NodePort' exposes via a high port on each node.
+# minecraft_service_type = "LoadBalancer"
+
 # Optional: agent-manager (Discord AI bot)
 # agent_manager_enabled    = true
 # agent_discord_bot_token  = "BOT_TOKEN"

--- a/terraform/linode/variables.tf
+++ b/terraform/linode/variables.tf
@@ -97,6 +97,17 @@ variable "storage_class" {
   default     = "linode-block-storage-retain"
 }
 
+variable "minecraft_service_type" {
+  description = "Kubernetes Service type for the Minecraft game port (25565). Use 'LoadBalancer' for a dedicated public IP on port 25565, or 'NodePort' to expose via a high-numbered port on each node."
+  type        = string
+  default     = "NodePort"
+
+  validation {
+    condition     = contains(["NodePort", "LoadBalancer"], var.minecraft_service_type)
+    error_message = "minecraft_service_type must be 'NodePort' or 'LoadBalancer'."
+  }
+}
+
 variable "helm_values_file" {
   description = "Optional path to a custom Helm values file to merge. Leave empty to use defaults."
   type        = string


### PR DESCRIPTION
## Summary

- Adds `minecraft_service_type` variable to all three Terraform modules (linode, existing-cluster, aws)
- Defaults to `NodePort` for backwards compatibility
- Set to `LoadBalancer` to get a dedicated public IP on the standard Minecraft port 25565 — no port number required to connect
- Validated to only allow `NodePort` or `LoadBalancer`
- Documents the option in all three `terraform.tfvars.example` files

## Motivation

With NodePort, players must connect to a non-standard high port (e.g. `50.116.58.95:31339`). LoadBalancer gives a clean dedicated IP on 25565 so players just enter the IP with no port suffix. Worth exposing as a first-class variable rather than requiring a custom values file override.

## Test plan

- [ ] `terraform fmt -check` and `terraform validate` pass on all three modules (CI validates this)
- [ ] Setting `TF_VAR_minecraft_service_type=LoadBalancer` results in a Kubernetes LoadBalancer service on port 25565

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_