### PR TITLE
fix(terraform): use toset() for optional dynamic for_each locals

### DIFF
--- a/terraform/aws/helm.tf
+++ b/terraform/aws/helm.tf
@@ -26,8 +26,8 @@ data "aws_eks_cluster_auth" "omcsi" {
 
 locals {
   use_custom_registry = var.image_registry != "" ? [1] : []
-  use_discord         = var.discord_webhook_url != "" ? [1] : []
-  use_deploy_token    = var.deploy_auth_token != "" ? [1] : []
+  use_discord         = toset(var.discord_webhook_url != "" ? ["enabled"] : [])
+  use_deploy_token    = toset(var.deploy_auth_token != "" ? ["enabled"] : [])
 }
 
 resource "kubernetes_namespace" "omcsi" {

--- a/terraform/existing-cluster/main.tf
+++ b/terraform/existing-cluster/main.tf
@@ -20,9 +20,9 @@ provider "helm" {
 
 locals {
   use_custom_registry = var.image_registry != "" ? [1] : []
-  use_storage_class   = var.storage_class != "" ? [1] : []
-  use_discord         = var.discord_webhook_url != "" ? [1] : []
-  use_deploy_token    = var.deploy_auth_token != "" ? [1] : []
+  use_storage_class   = toset(var.storage_class != "" ? ["enabled"] : [])
+  use_discord         = toset(var.discord_webhook_url != "" ? ["enabled"] : [])
+  use_deploy_token    = toset(var.deploy_auth_token != "" ? ["enabled"] : [])
 }
 
 resource "kubernetes_namespace" "omcsi" {

--- a/terraform/linode/helm.tf
+++ b/terraform/linode/helm.tf
@@ -5,8 +5,8 @@
 locals {
   kubeconfig          = yamldecode(base64decode(linode_lke_cluster.omcsi.kubeconfig))
   use_custom_registry = var.image_registry != "" ? [1] : []
-  use_discord         = var.discord_webhook_url != "" ? [1] : []
-  use_deploy_token    = var.deploy_auth_token != "" ? [1] : []
+  use_discord         = toset(var.discord_webhook_url != "" ? ["enabled"] : [])
+  use_deploy_token    = toset(var.deploy_auth_token != "" ? ["enabled"] : [])
 }
 
 provider "kubernetes" {


### PR DESCRIPTION
## Summary
- Variables with empty-string defaults (`discord_webhook_url`, `deploy_auth_token`, `storage_class`) evaluate to an untyped `tuple([])` at `terraform validate` time, which is rejected by `for_each` in dynamic blocks
- Fix: wrap with `toset()` so the result is always a typed `set(string)`, accepted in both empty and non-empty cases
- Affects all three Terraform modules (linode, existing-cluster, aws)

## Test plan
- [ ] `terraform validate` CI check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_