### PR TITLE
fix(traefik): replace removed v3 chart values with additionalArguments

### DIFF
--- a/terraform/aws/traefik.tf
+++ b/terraform/aws/traefik.tf
@@ -87,10 +87,9 @@ resource "helm_release" "traefik" {
         protocol: TCP
     service:
       type: LoadBalancer
-    providers:
-      file:
-        directory: /etc/traefik/dynamic
-        watch: true
+    additionalArguments:
+      - "--providers.file.directory=/etc/traefik/dynamic"
+      - "--providers.file.watch=true"
     deployment:
       additionalVolumes:
         - name: dynamic-config
@@ -99,7 +98,6 @@ resource "helm_release" "traefik" {
     additionalVolumeMounts:
       - name: dynamic-config
         mountPath: /etc/traefik/dynamic
-    globalArguments: []
     logs:
       general:
         level: INFO

--- a/terraform/existing-cluster/traefik.tf
+++ b/terraform/existing-cluster/traefik.tf
@@ -87,10 +87,9 @@ resource "helm_release" "traefik" {
         protocol: TCP
     service:
       type: LoadBalancer
-    providers:
-      file:
-        directory: /etc/traefik/dynamic
-        watch: true
+    additionalArguments:
+      - "--providers.file.directory=/etc/traefik/dynamic"
+      - "--providers.file.watch=true"
     deployment:
       additionalVolumes:
         - name: dynamic-config
@@ -99,7 +98,6 @@ resource "helm_release" "traefik" {
     additionalVolumeMounts:
       - name: dynamic-config
         mountPath: /etc/traefik/dynamic
-    globalArguments: []
     logs:
       general:
         level: INFO

--- a/terraform/linode/traefik.tf
+++ b/terraform/linode/traefik.tf
@@ -100,10 +100,9 @@ resource "helm_release" "traefik" {
         protocol: TCP
     service:
       type: LoadBalancer
-    providers:
-      file:
-        directory: /etc/traefik/dynamic
-        watch: true
+    additionalArguments:
+      - "--providers.file.directory=/etc/traefik/dynamic"
+      - "--providers.file.watch=true"
     deployment:
       additionalVolumes:
         - name: dynamic-config
@@ -112,7 +111,6 @@ resource "helm_release" "traefik" {
     additionalVolumeMounts:
       - name: dynamic-config
         mountPath: /etc/traefik/dynamic
-    globalArguments: []
     logs:
       general:
         level: INFO


### PR DESCRIPTION
## Summary

- Removes `globalArguments: []` (dropped in Traefik v3 / chart v40)
- Removes `providers.file.directory` and `providers.file.watch` Helm values (no longer in v40 schema)
- Adds `additionalArguments` with `--providers.file.directory` and `--providers.file.watch` flags, which are the correct way to configure the file provider in Traefik v3

Applies to all three Terraform modules (`linode`, `existing-cluster`, `aws`).

## Test plan
- [ ] CI `Terraform Validate` passes on this branch
- [ ] After merge, `terraform apply` deploys Traefik successfully and the single LoadBalancer IP routes Minecraft (25565), HTTP (80), and HTTPS (443)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_