### PR TITLE
feat: Wave 1 reliability — health probes, startup ordering, PodDisruptionBudgets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,29 @@ jobs:
         echo "⎈ Linting Helm chart..."
         helm lint helm/omcsi --set secrets.rconPassword=ci --set secrets.adminPassword=ci
         echo "✓ Helm chart linted successfully"
-        
+
+  helm-unit-test:
+    name: Helm Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Helm
+      uses: azure/setup-helm@v4
+      with:
+        version: 'v3.17.0'
+
+    - name: Install helm-unittest plugin
+      run: helm plugin install https://github.com/helm-unittest/helm-unittest
+
+    - name: Run Helm unit tests
+      run: |
+        echo "⎈ Running Helm unit tests..."
+        helm unittest helm/omcsi
+        echo "✓ All Helm unit tests passed"
+
   helm-deploy-test:
     name: Helm Deploy Smoke Test
     runs-on: ubuntu-latest
@@ -200,6 +222,41 @@ jobs:
         echo "🔍 Verifying ConfigMap..."
         kubectl get configmap omcsi-nginx-config -o name
         echo "  ✓ ConfigMap omcsi-nginx-config exists"
+
+    - name: Verify PodDisruptionBudgets
+      run: |
+        echo "🔍 Verifying PodDisruptionBudgets..."
+        for pdb in minecraft-wrapper webapp alert-manager; do
+          kubectl get pdb "omcsi-${pdb}" -o name
+          echo "  ✓ PDB omcsi-${pdb} exists"
+        done
+
+    - name: Verify health probes and webapp init container
+      run: |
+        echo "🔍 Verifying startup probe on minecraft-wrapper..."
+        STARTUP_PATH=$(kubectl get deployment omcsi-minecraft-wrapper \
+          -o jsonpath='{.spec.template.spec.containers[0].startupProbe.httpGet.path}')
+        [ "${STARTUP_PATH}" = "/actuator/health" ] || \
+          { echo "FAIL: startupProbe path '${STARTUP_PATH}' != /actuator/health"; exit 1; }
+        STARTUP_FT=$(kubectl get deployment omcsi-minecraft-wrapper \
+          -o jsonpath='{.spec.template.spec.containers[0].startupProbe.failureThreshold}')
+        [ "${STARTUP_FT}" = "60" ] || \
+          { echo "FAIL: startupProbe failureThreshold '${STARTUP_FT}' != 60"; exit 1; }
+        echo "  ✓ minecraft-wrapper startup probe (failureThreshold=60)"
+
+        echo "🔍 Verifying liveness probe on backup-manager..."
+        BM_LIVE=$(kubectl get deployment omcsi-backup-manager \
+          -o jsonpath='{.spec.template.spec.containers[0].livenessProbe.httpGet.path}')
+        [ "${BM_LIVE}" = "/actuator/health" ] || \
+          { echo "FAIL: backup-manager livenessProbe path '${BM_LIVE}' != /actuator/health"; exit 1; }
+        echo "  ✓ backup-manager liveness probe"
+
+        echo "🔍 Verifying wait-for-wrapper init container on webapp..."
+        INIT_NAME=$(kubectl get deployment omcsi-webapp \
+          -o jsonpath='{.spec.template.spec.initContainers[0].name}')
+        [ "${INIT_NAME}" = "wait-for-wrapper" ] || \
+          { echo "FAIL: webapp init container '${INIT_NAME}' != wait-for-wrapper"; exit 1; }
+        echo "  ✓ webapp wait-for-wrapper init container"
 
     - name: Verify Service types and ports
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,10 @@ jobs:
     - name: Set up Helm
       uses: azure/setup-helm@v4
       with:
-        version: 'v3.17.0'
+        # helm-unittest v1.x uses `platformHooks` in plugin.yaml, which requires
+        # Helm v3.18+. The lint/smoke-test jobs pin v3.17 for stability; this
+        # job needs a newer version so the plugin installs without error.
+        version: 'v3.20.0'
 
     - name: Install helm-unittest plugin
       run: helm plugin install https://github.com/helm-unittest/helm-unittest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
         version: 'v3.20.0'
 
     - name: Install helm-unittest plugin
-      run: helm plugin install https://github.com/helm-unittest/helm-unittest
+      run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.0
 
     - name: Run Helm unit tests
       run: |

--- a/agent-manager/README.md
+++ b/agent-manager/README.md
@@ -298,7 +298,7 @@ At DEBUG level, the agent-manager logs additional detail at each step:
 - Only the user who requested an action can confirm it via reaction
 - Pending confirmations expire after 5 minutes to prevent stale actions
 - The Discord bot only listens in the configured channel
-- The Actuator management endpoints (`/loggers`, `/health`) run on a separate port (8094). In Docker Compose this port is not mapped to the host, so it is only reachable from within the Docker network. In Kubernetes it is not exposed via any Service, so it is only reachable by the kubelet (for health probes) within the cluster
+- The Actuator management endpoints (`/loggers`, `/health`) run on a separate port (8094). In Docker Compose this port is not mapped to the host, so it is only reachable from within the Docker network. In Kubernetes it is not exposed via any Service or Ingress, but it remains reachable on the cluster network via the pod IP (including by the kubelet for health probes). Use NetworkPolicies to restrict access if required
 
 ## Troubleshooting
 

--- a/agent-manager/README.md
+++ b/agent-manager/README.md
@@ -298,7 +298,7 @@ At DEBUG level, the agent-manager logs additional detail at each step:
 - Only the user who requested an action can confirm it via reaction
 - Pending confirmations expire after 5 minutes to prevent stale actions
 - The Discord bot only listens in the configured channel
-- The Actuator management endpoints (`/loggers`, `/health`) run on a separate port (8094) and are bound to `127.0.0.1` — only accessible from inside the container
+- The Actuator management endpoints (`/loggers`, `/health`) run on a separate port (8094). In Docker Compose this port is not mapped to the host, so it is only reachable from within the Docker network. In Kubernetes it is not exposed via any Service, so it is only reachable by the kubelet (for health probes) within the cluster
 
 ## Troubleshooting
 

--- a/agent-manager/src/main/resources/application.properties
+++ b/agent-manager/src/main/resources/application.properties
@@ -53,8 +53,10 @@ webapp.url=${WEBAPP_URL:http://webapp:8080}
 # Actuator configuration for health checks and dynamic log management
 management.endpoints.web.exposure.include=health,loggers
 management.endpoint.health.show-details=always
+# Management endpoints run on a dedicated port (8094) so they can be separated
+# from the main API (8093) in Service routing. The address is not restricted to
+# localhost so that the Kubernetes kubelet can reach /actuator/health for probes.
 management.server.port=8094
-management.server.address=127.0.0.1
 
 # Logging configuration
 logging.level.com.openmc.agentmanager=INFO

--- a/backup-manager/build.gradle
+++ b/backup-manager/build.gradle
@@ -26,6 +26,7 @@ configurations {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'io.swagger.core.v3:swagger-annotations:2.2.19'
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'

--- a/docs/KUBERNETES_IMPROVEMENTS.md
+++ b/docs/KUBERNETES_IMPROVEMENTS.md
@@ -20,18 +20,14 @@ This document captures issues, limitations, and improvement opportunities surfac
 
 ---
 
-## 2. Health Probes — Missing for Several Services
+## 2. Health Probes — Missing for Several Services ✅ Resolved
 
-**Problem:** Only `alert-manager`, `webapp`, and `nginx` have health probes defined. The following services have **no** liveness, readiness, or startup probes:
-- `minecraft-wrapper` — the Minecraft server can take several minutes to start; without a startup probe, Kubernetes may kill the pod prematurely.
-- `backup-manager` — no probe to confirm the Spring Boot app started successfully.
-- `agent-manager` — no probe to confirm the Discord bot connected.
+**Problem:** Only `alert-manager`, `webapp`, and `nginx` had health probes defined. `minecraft-wrapper`, `backup-manager`, and `agent-manager` had no liveness, readiness, or startup probes.
 
-**Suggested improvements:**
-- Add a `startupProbe` to `minecraft-wrapper` with a generous `failureThreshold` (e.g., 30 × 10s = 5 minutes) to accommodate Spigot's build-on-first-run behavior.
-- Add `livenessProbe` and `readinessProbe` to `backup-manager` and `agent-manager` targeting their Spring Boot actuator health endpoints (e.g., `/actuator/health`).
-
-**Priority:** Medium — improves restart reliability and zero-downtime upgrades.
+**Resolution:** Health probes added to all services in [PR #153](https://github.com/dmccoystephenson/open-mc-server-infrastructure/pull/153):
+- `minecraft-wrapper`: `startupProbe` with `failureThreshold: 60 × periodSeconds: 10` = 10 minutes (accommodates Spigot's build-on-first-run compilation), plus `livenessProbe` and `readinessProbe` on the wrapper API port.
+- `backup-manager`: `livenessProbe` and `readinessProbe` on `/actuator/health`.
+- `agent-manager`: `livenessProbe` and `readinessProbe` on `/actuator/health` via the dedicated management port (8094). The management port address restriction (`127.0.0.1`) was removed so the kubelet can reach the probe endpoint.
 
 ---
 
@@ -114,15 +110,16 @@ This document captures issues, limitations, and improvement opportunities surfac
 
 ---
 
-## 9. Pod Disruption Budgets (PDB)
+## 9. Pod Disruption Budgets (PDB) ✅ Resolved
 
-**Problem:** No `PodDisruptionBudget` resources are defined. During node maintenance or cluster upgrades, all pods (including the Minecraft server) can be evicted simultaneously.
+**Problem:** No `PodDisruptionBudget` resources were defined. During node maintenance or cluster upgrades, all pods (including the Minecraft server) could be evicted simultaneously.
 
-**Suggested improvements:**
-- Add a PDB for `minecraft-wrapper` ensuring `minAvailable: 1` (the server should never have zero available replicas during voluntary disruptions).
-- Add PDBs for critical supporting services (webapp, alert-manager) when running multiple replicas.
+**Resolution:** PDBs added to `helm/omcsi/templates/pdb.yaml` in [PR #153](https://github.com/dmccoystephenson/open-mc-server-infrastructure/pull/153):
+- `minecraft-wrapper`: `minAvailable: 1` — prevents voluntary eviction of the live server.
+- `webapp`: `minAvailable: 1` — keeps the admin dashboard available during drains.
+- `alert-manager`: `minAvailable: 1` — prevents monitoring from going silent during maintenance.
 
-**Priority:** Low — relevant for production clusters with regular maintenance windows.
+All three PDBs use `policy/v1` (stable since Kubernetes 1.21).
 
 ---
 
@@ -157,13 +154,13 @@ This document captures issues, limitations, and improvement opportunities surfac
 | # | Improvement | Priority | Effort |
 |---|---|---|---|
 | 1 | ~~Backup manager — native filesystem mode~~ ✅ Resolved | ~~High~~ | ~~Medium~~ |
-| 2 | Health probes for all services | Medium | Low |
+| 2 | ~~Health probes for all services~~ ✅ Resolved | ~~Medium~~ | ~~Low~~ |
 | 3 | Security contexts | Medium | Low |
 | 4 | Ingress controller support | Medium | Medium |
 | 5 | TLS certificate management (cert-manager) | Low | Medium |
 | 6 | Shared PVC scheduling improvements | Low | Medium |
 | 7 | Horizontal Pod Autoscaler | Low | Low |
 | 8 | Network policies | Low | Medium |
-| 9 | Pod Disruption Budgets | Low | Low |
+| 9 | ~~Pod Disruption Budgets~~ ✅ Resolved | ~~Low~~ | ~~Low~~ |
 | 10 | Helm chart publishing | Low | Low |
 | 11 | Monitoring and observability | Low | Medium |

--- a/helm/omcsi/templates/agent-manager.yaml
+++ b/helm/omcsi/templates/agent-manager.yaml
@@ -69,6 +69,22 @@ spec:
               value: {{ .Values.agentManager.env.DIAGNOSTICS_LOGS_MAX_LINES | quote }}
             - name: DIAGNOSTICS_LOGS_ANONYMIZE
               value: {{ .Values.agentManager.env.DIAGNOSTICS_LOGS_ANONYMIZE | quote }}
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
           resources:
             {{- toYaml .Values.agentManager.resources | nindent 12 }}
 ---

--- a/helm/omcsi/templates/agent-manager.yaml
+++ b/helm/omcsi/templates/agent-manager.yaml
@@ -27,6 +27,9 @@ spec:
             - name: http
               containerPort: 8093
               protocol: TCP
+            - name: management
+              containerPort: 8094
+              protocol: TCP
           env:
             - name: AGENT_DISCORD_BOT_TOKEN
               valueFrom:
@@ -72,7 +75,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /actuator/health
-              port: http
+              port: management
             initialDelaySeconds: 30
             periodSeconds: 30
             timeoutSeconds: 5
@@ -80,7 +83,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /actuator/health
-              port: http
+              port: management
             initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5

--- a/helm/omcsi/templates/backup-manager.yaml
+++ b/helm/omcsi/templates/backup-manager.yaml
@@ -49,6 +49,22 @@ spec:
               value: {{ .Values.backupManager.env.ALERTS_BACKUP_FAILURE | quote }}
             - name: ALERT_MANAGER_URL
               value: "http://{{ include "omcsi.alertManagerHost" . }}:{{ .Values.alertManager.service.port }}/api/alerts"
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
           resources:
             {{- toYaml .Values.backupManager.resources | nindent 12 }}
           volumeMounts:

--- a/helm/omcsi/templates/minecraft-wrapper.yaml
+++ b/helm/omcsi/templates/minecraft-wrapper.yaml
@@ -104,6 +104,30 @@ spec:
               value: {{ .Values.minecraftWrapper.env.LOGS_DIAGNOSTIC_ENABLED | quote }}
             - name: LOGS_DIAGNOSTIC_MAX_LINES
               value: {{ .Values.minecraftWrapper.env.LOGS_DIAGNOSTIC_MAX_LINES | quote }}
+          # startupProbe gives the JVM time to initialise before liveness kicks in.
+          # failureThreshold × periodSeconds = 10 minutes — enough for Spigot's
+          # first-boot BuildTools compilation.
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: wrapper
+            failureThreshold: 60
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: wrapper
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: wrapper
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
           resources:
             {{- toYaml .Values.minecraftWrapper.resources | nindent 12 }}
           volumeMounts:

--- a/helm/omcsi/templates/pdb.yaml
+++ b/helm/omcsi/templates/pdb.yaml
@@ -1,7 +1,8 @@
+{{- if .Values.podDisruptionBudgets.enabled }}
 # PodDisruptionBudgets prevent voluntary evictions (node drain, cluster
 # upgrades) from taking these services offline without operator intent.
-# minecraft-wrapper is protected unconditionally; webapp and alert-manager
-# are protected so a drain does not silently remove monitoring/access.
+# Disable with podDisruptionBudgets.enabled=false on single-node clusters
+# where drain operations would otherwise be permanently blocked.
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -37,3 +38,4 @@ spec:
   selector:
     matchLabels:
       {{- include "omcsi.selectorLabels" (dict "root" . "component" "alert-manager") | nindent 6 }}
+{{- end }}

--- a/helm/omcsi/templates/pdb.yaml
+++ b/helm/omcsi/templates/pdb.yaml
@@ -1,0 +1,39 @@
+# PodDisruptionBudgets prevent voluntary evictions (node drain, cluster
+# upgrades) from taking these services offline without operator intent.
+# minecraft-wrapper is protected unconditionally; webapp and alert-manager
+# are protected so a drain does not silently remove monitoring/access.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "omcsi.fullname" . }}-minecraft-wrapper
+  labels:
+    {{- include "omcsi.labels" . | nindent 4 }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      {{- include "omcsi.selectorLabels" (dict "root" . "component" "minecraft-wrapper") | nindent 6 }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "omcsi.fullname" . }}-webapp
+  labels:
+    {{- include "omcsi.labels" . | nindent 4 }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      {{- include "omcsi.selectorLabels" (dict "root" . "component" "webapp") | nindent 6 }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "omcsi.fullname" . }}-alert-manager
+  labels:
+    {{- include "omcsi.labels" . | nindent 4 }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      {{- include "omcsi.selectorLabels" (dict "root" . "component" "alert-manager") | nindent 6 }}

--- a/helm/omcsi/templates/pdb.yaml
+++ b/helm/omcsi/templates/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.podDisruptionBudgets.enabled }}
+{{- if ne "false" (toString ((.Values.podDisruptionBudgets).enabled)) }}
 # PodDisruptionBudgets prevent voluntary evictions (node drain, cluster
 # upgrades) from taking these services offline without operator intent.
 # Disable with podDisruptionBudgets.enabled=false on single-node clusters

--- a/helm/omcsi/templates/webapp.yaml
+++ b/helm/omcsi/templates/webapp.yaml
@@ -29,10 +29,17 @@ spec:
             - sh
             - -c
             - |
-              until wget -qO /dev/null http://{{ include "omcsi.minecraftWrapperHost" . }}-internal:{{ .Values.minecraftWrapper.internalService.wrapperPort }}/actuator/health; do
-                echo "Waiting for minecraft-wrapper...";
-                sleep 5;
+              attempt=0
+              until wget -T 5 -qO /dev/null http://{{ include "omcsi.minecraftWrapperHost" . }}-internal:{{ .Values.minecraftWrapper.internalService.wrapperPort }}/actuator/health; do
+                attempt=$((attempt + 1))
+                if [ "$attempt" -ge 60 ]; then
+                  echo "ERROR: minecraft-wrapper did not become healthy after $attempt attempts. Check wrapper logs."
+                  exit 1
+                fi
+                echo "Waiting for minecraft-wrapper (attempt $attempt/60)..."
+                sleep 5
               done
+              echo "minecraft-wrapper is healthy"
       containers:
         - name: webapp
           image: "{{ .Values.webapp.image.repository }}:{{ .Values.webapp.image.tag }}"

--- a/helm/omcsi/templates/webapp.yaml
+++ b/helm/omcsi/templates/webapp.yaml
@@ -22,6 +22,17 @@ spec:
         {{- include "omcsi.selectorLabels" (dict "root" . "component" "webapp") | nindent 8 }}
     spec:
       {{- include "omcsi.mcserverAffinity" . | nindent 6 }}
+      initContainers:
+        - name: wait-for-wrapper
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              until wget -qO /dev/null http://{{ include "omcsi.minecraftWrapperHost" . }}-internal:{{ .Values.minecraftWrapper.internalService.wrapperPort }}/actuator/health; do
+                echo "Waiting for minecraft-wrapper...";
+                sleep 5;
+              done
       containers:
         - name: webapp
           image: "{{ .Values.webapp.image.repository }}:{{ .Values.webapp.image.tag }}"

--- a/helm/omcsi/tests/agent_manager_test.yaml
+++ b/helm/omcsi/tests/agent_manager_test.yaml
@@ -1,0 +1,88 @@
+suite: agent-manager conditional rendering
+templates:
+  - templates/agent-manager.yaml
+set:
+  secrets.rconPassword: ci
+  secrets.adminPassword: ci
+tests:
+  - it: renders nothing when disabled (default)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders Deployment and Service when enabled
+    set:
+      agentManager.enabled: true
+      secrets.agentDiscordBotToken: ci-token
+      secrets.agentDiscordChannelId: "123456"
+      secrets.agentAnthropicApiKey: ci-key
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: Deployment has liveness probe when enabled
+    set:
+      agentManager.enabled: true
+      secrets.agentDiscordBotToken: ci-token
+      secrets.agentDiscordChannelId: "123456"
+      secrets.agentAnthropicApiKey: ci-key
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /actuator/health
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: http
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
+          value: 30
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.failureThreshold
+          value: 5
+        documentIndex: 0
+
+  - it: Deployment has readiness probe when enabled
+    set:
+      agentManager.enabled: true
+      secrets.agentDiscordBotToken: ci-token
+      secrets.agentDiscordChannelId: "123456"
+      secrets.agentAnthropicApiKey: ci-key
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /actuator/health
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: http
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.initialDelaySeconds
+          value: 30
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.failureThreshold
+          value: 3
+        documentIndex: 0
+
+  - it: Service is ClusterIP on port 8093 when enabled
+    set:
+      agentManager.enabled: true
+      secrets.agentDiscordBotToken: ci-token
+      secrets.agentDiscordChannelId: "123456"
+      secrets.agentAnthropicApiKey: ci-key
+    asserts:
+      - isKind:
+          of: Service
+        documentIndex: 1
+      - equal:
+          path: spec.type
+          value: ClusterIP
+        documentIndex: 1
+      - equal:
+          path: spec.ports[0].port
+          value: 8093
+        documentIndex: 1

--- a/helm/omcsi/tests/agent_manager_test.yaml
+++ b/helm/omcsi/tests/agent_manager_test.yaml
@@ -20,7 +20,7 @@ tests:
       - hasDocuments:
           count: 2
 
-  - it: Deployment has liveness probe when enabled
+  - it: Deployment has liveness probe on the management port when enabled
     set:
       agentManager.enabled: true
       secrets.agentDiscordBotToken: ci-token
@@ -33,7 +33,7 @@ tests:
         documentIndex: 0
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.port
-          value: http
+          value: management
         documentIndex: 0
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
@@ -44,7 +44,7 @@ tests:
           value: 5
         documentIndex: 0
 
-  - it: Deployment has readiness probe when enabled
+  - it: Deployment has readiness probe on the management port when enabled
     set:
       agentManager.enabled: true
       secrets.agentDiscordBotToken: ci-token
@@ -57,7 +57,7 @@ tests:
         documentIndex: 0
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.port
-          value: http
+          value: management
         documentIndex: 0
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.initialDelaySeconds

--- a/helm/omcsi/tests/alert_manager_test.yaml
+++ b/helm/omcsi/tests/alert_manager_test.yaml
@@ -1,0 +1,73 @@
+suite: alert-manager
+templates:
+  - templates/alert-manager.yaml
+set:
+  secrets.rconPassword: ci
+  secrets.adminPassword: ci
+tests:
+  - it: Deployment is the first document
+    asserts:
+      - isKind:
+          of: Deployment
+        documentIndex: 0
+
+  - it: liveness probe monitors /actuator/health
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /actuator/health
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: http
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
+          value: 30
+        documentIndex: 0
+
+  - it: readiness probe monitors /actuator/health
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /actuator/health
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: http
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.initialDelaySeconds
+          value: 30
+        documentIndex: 0
+
+  - it: service is ClusterIP on port 8090
+    asserts:
+      - isKind:
+          of: Service
+        documentIndex: 1
+      - equal:
+          path: spec.type
+          value: ClusterIP
+        documentIndex: 1
+      - equal:
+          path: spec.ports[0].port
+          value: 8090
+        documentIndex: 1
+
+  - it: uses PVC for alert-manager-data when persistence is enabled
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.volumes[0].persistentVolumeClaim
+        documentIndex: 0
+
+  - it: uses emptyDir for alert-manager-data when persistence is disabled
+    set:
+      persistence.alertManagerData.enabled: false
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.volumes[0].emptyDir
+        documentIndex: 0
+      - isNull:
+          path: spec.template.spec.volumes[0].persistentVolumeClaim
+        documentIndex: 0

--- a/helm/omcsi/tests/backup_manager_test.yaml
+++ b/helm/omcsi/tests/backup_manager_test.yaml
@@ -1,0 +1,100 @@
+suite: backup-manager
+templates:
+  - templates/backup-manager.yaml
+set:
+  secrets.rconPassword: ci
+  secrets.adminPassword: ci
+tests:
+  - it: Deployment is the first document
+    asserts:
+      - isKind:
+          of: Deployment
+        documentIndex: 0
+
+  - it: liveness probe monitors /actuator/health
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /actuator/health
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: http
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
+          value: 30
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.failureThreshold
+          value: 5
+        documentIndex: 0
+
+  - it: readiness probe monitors /actuator/health
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /actuator/health
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: http
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.initialDelaySeconds
+          value: 30
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.failureThreshold
+          value: 3
+        documentIndex: 0
+
+  - it: mounts mcserver read-only and backups volumes
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: mcserver
+            mountPath: /mcserver
+            readOnly: true
+        documentIndex: 0
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: backups
+            mountPath: /backups
+        documentIndex: 0
+
+  - it: service is ClusterIP on port 8091
+    asserts:
+      - isKind:
+          of: Service
+        documentIndex: 1
+      - equal:
+          path: spec.type
+          value: ClusterIP
+        documentIndex: 1
+      - equal:
+          path: spec.ports[0].port
+          value: 8091
+        documentIndex: 1
+
+  - it: backup schedule env var is set from values
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BACKUP_SCHEDULE
+            value: "0 0 2 * * ?"
+        documentIndex: 0
+
+  - it: backup schedule env var is omitted when empty string
+    set:
+      backupManager.env.BACKUP_SCHEDULE: ""
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BACKUP_SCHEDULE
+          any: true
+        documentIndex: 0

--- a/helm/omcsi/tests/minecraft_wrapper_test.yaml
+++ b/helm/omcsi/tests/minecraft_wrapper_test.yaml
@@ -1,0 +1,167 @@
+suite: minecraft-wrapper
+templates:
+  - templates/minecraft-wrapper.yaml
+set:
+  secrets.rconPassword: ci
+  secrets.adminPassword: ci
+tests:
+  - it: Deployment is the first document
+    asserts:
+      - isKind:
+          of: Deployment
+        documentIndex: 0
+
+  - it: hardcodes replica count to 1
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 1
+        documentIndex: 0
+
+  - it: uses Recreate strategy (world data must not be shared)
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+        documentIndex: 0
+
+  - it: startup probe gives the JVM up to 10 minutes before liveness kicks in
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /actuator/health
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.port
+          value: wrapper
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 60
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.periodSeconds
+          value: 10
+        documentIndex: 0
+
+  - it: liveness probe restarts unresponsive wrapper
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /actuator/health
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: wrapper
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.periodSeconds
+          value: 30
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.failureThreshold
+          value: 5
+        documentIndex: 0
+
+  - it: readiness probe gates traffic until wrapper is healthy
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /actuator/health
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: wrapper
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.periodSeconds
+          value: 10
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.failureThreshold
+          value: 3
+        documentIndex: 0
+
+  - it: mounts mcserver volume at /mcserver
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: mcserver
+            mountPath: /mcserver
+        documentIndex: 0
+
+  - it: external service is NodePort on Minecraft port 25565
+    asserts:
+      - isKind:
+          of: Service
+        documentIndex: 1
+      - equal:
+          path: spec.type
+          value: NodePort
+        documentIndex: 1
+      - equal:
+          path: spec.ports[0].port
+          value: 25565
+        documentIndex: 1
+
+  - it: internal service is ClusterIP exposing RCON, BlueMap, and wrapper ports
+    asserts:
+      - isKind:
+          of: Service
+        documentIndex: 2
+      - equal:
+          path: spec.type
+          value: ClusterIP
+        documentIndex: 2
+      - equal:
+          path: spec.ports[0].name
+          value: rcon
+        documentIndex: 2
+      - equal:
+          path: spec.ports[0].port
+          value: 25575
+        documentIndex: 2
+      - equal:
+          path: spec.ports[1].name
+          value: bluemap
+        documentIndex: 2
+      - equal:
+          path: spec.ports[1].port
+          value: 8100
+        documentIndex: 2
+      - equal:
+          path: spec.ports[2].name
+          value: wrapper
+        documentIndex: 2
+      - equal:
+          path: spec.ports[2].port
+          value: 8092
+        documentIndex: 2
+
+  - it: external service type is configurable
+    set:
+      minecraftWrapper.service.type: LoadBalancer
+    asserts:
+      - equal:
+          path: spec.type
+          value: LoadBalancer
+        documentIndex: 1
+
+  - it: uses emptyDir for mcserver volume when persistence is disabled
+    set:
+      persistence.mcserver.enabled: false
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.volumes[0].emptyDir
+        documentIndex: 0
+      - isNull:
+          path: spec.template.spec.volumes[0].persistentVolumeClaim
+        documentIndex: 0
+
+  - it: uses PVC for mcserver volume when persistence is enabled
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].persistentVolumeClaim.claimName
+          value: RELEASE-NAME-omcsi-mcserver
+        documentIndex: 0

--- a/helm/omcsi/tests/pdb_test.yaml
+++ b/helm/omcsi/tests/pdb_test.yaml
@@ -1,0 +1,86 @@
+suite: PodDisruptionBudgets
+templates:
+  - templates/pdb.yaml
+set:
+  secrets.rconPassword: ci
+  secrets.adminPassword: ci
+tests:
+  - it: renders three PodDisruptionBudgets
+    asserts:
+      - hasDocuments:
+          count: 3
+
+  - it: all PDBs use policy/v1 (stable since K8s 1.21)
+    asserts:
+      - isAPIVersion:
+          of: policy/v1
+        documentIndex: 0
+      - isAPIVersion:
+          of: policy/v1
+        documentIndex: 1
+      - isAPIVersion:
+          of: policy/v1
+        documentIndex: 2
+
+  - it: minecraft-wrapper PDB has minAvailable 1
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+        documentIndex: 0
+      - equal:
+          path: spec.minAvailable
+          value: 1
+        documentIndex: 0
+      - matchRegex:
+          path: metadata.name
+          pattern: minecraft-wrapper
+        documentIndex: 0
+
+  - it: minecraft-wrapper PDB selects the correct component
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: minecraft-wrapper
+        documentIndex: 0
+
+  - it: webapp PDB has minAvailable 1
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+        documentIndex: 1
+      - equal:
+          path: spec.minAvailable
+          value: 1
+        documentIndex: 1
+      - matchRegex:
+          path: metadata.name
+          pattern: webapp
+        documentIndex: 1
+
+  - it: webapp PDB selects the correct component
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: webapp
+        documentIndex: 1
+
+  - it: alert-manager PDB has minAvailable 1
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+        documentIndex: 2
+      - equal:
+          path: spec.minAvailable
+          value: 1
+        documentIndex: 2
+      - matchRegex:
+          path: metadata.name
+          pattern: alert-manager
+        documentIndex: 2
+
+  - it: alert-manager PDB selects the correct component
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: alert-manager
+        documentIndex: 2

--- a/helm/omcsi/tests/pdb_test.yaml
+++ b/helm/omcsi/tests/pdb_test.yaml
@@ -5,10 +5,17 @@ set:
   secrets.rconPassword: ci
   secrets.adminPassword: ci
 tests:
-  - it: renders three PodDisruptionBudgets
+  - it: renders three PodDisruptionBudgets when enabled (default)
     asserts:
       - hasDocuments:
           count: 3
+
+  - it: renders no documents when podDisruptionBudgets.enabled is false
+    set:
+      podDisruptionBudgets.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
 
   - it: all PDBs use policy/v1 (stable since K8s 1.21)
     asserts:

--- a/helm/omcsi/tests/pdb_test.yaml
+++ b/helm/omcsi/tests/pdb_test.yaml
@@ -17,6 +17,13 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: renders three PDBs when podDisruptionBudgets key is absent (backward compat)
+    set:
+      podDisruptionBudgets: null
+    asserts:
+      - hasDocuments:
+          count: 3
+
   - it: all PDBs use policy/v1 (stable since K8s 1.21)
     asserts:
       - isAPIVersion:

--- a/helm/omcsi/tests/pvc_test.yaml
+++ b/helm/omcsi/tests/pvc_test.yaml
@@ -1,0 +1,68 @@
+suite: PersistentVolumeClaims
+templates:
+  - templates/pvc.yaml
+set:
+  secrets.rconPassword: ci
+  secrets.adminPassword: ci
+tests:
+  - it: renders four PVCs when all persistence is enabled (default)
+    asserts:
+      - hasDocuments:
+          count: 4
+
+  - it: mcserver PVC uses ReadWriteOnce and 10Gi
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+        documentIndex: 0
+      - equal:
+          path: spec.accessModes[0]
+          value: ReadWriteOnce
+        documentIndex: 0
+      - equal:
+          path: spec.resources.requests.storage
+          value: 10Gi
+        documentIndex: 0
+
+  - it: mcserver PVC has no storageClassName when storageClass is empty (uses cluster default)
+    asserts:
+      - isNull:
+          path: spec.storageClassName
+        documentIndex: 0
+
+  - it: mcserver PVC sets storageClassName when a storageClass is provided
+    set:
+      persistence.mcserver.storageClass: linode-block-storage-retain
+    asserts:
+      - equal:
+          path: spec.storageClassName
+          value: linode-block-storage-retain
+        documentIndex: 0
+
+  - it: webappData PVC uses ReadWriteOnce and 1Gi
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+        documentIndex: 1
+      - equal:
+          path: spec.accessModes[0]
+          value: ReadWriteOnce
+        documentIndex: 1
+      - equal:
+          path: spec.resources.requests.storage
+          value: 1Gi
+        documentIndex: 1
+
+  - it: backups PVC uses ReadWriteOnce and 20Gi
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+        documentIndex: 3
+      - equal:
+          path: spec.accessModes[0]
+          value: ReadWriteOnce
+        documentIndex: 3
+      - equal:
+          path: spec.resources.requests.storage
+          value: 20Gi
+        documentIndex: 3

--- a/helm/omcsi/tests/webapp_test.yaml
+++ b/helm/omcsi/tests/webapp_test.yaml
@@ -1,0 +1,91 @@
+suite: webapp
+templates:
+  - templates/webapp.yaml
+set:
+  secrets.rconPassword: ci
+  secrets.adminPassword: ci
+tests:
+  - it: Deployment is the first document
+    asserts:
+      - isKind:
+          of: Deployment
+        documentIndex: 0
+
+  - it: has an init container named wait-for-wrapper
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: wait-for-wrapper
+        documentIndex: 0
+
+  - it: init container uses busybox 1.36
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: busybox:1.36
+        documentIndex: 0
+
+  - it: init container polls the minecraft-wrapper internal health endpoint
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "minecraft-wrapper-internal.*actuator/health"
+        documentIndex: 0
+
+  - it: mounts mcserver and webapp-data volumes
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: mcserver
+            mountPath: /mcserver
+        documentIndex: 0
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: webapp-data
+            mountPath: /app/data
+        documentIndex: 0
+
+  - it: uses PVC for webapp-data when persistence is enabled
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].persistentVolumeClaim.claimName
+          value: RELEASE-NAME-omcsi-webapp-data
+        documentIndex: 0
+
+  - it: uses emptyDir for webapp-data when persistence is disabled
+    set:
+      persistence.webappData.enabled: false
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.volumes[0].emptyDir
+        documentIndex: 0
+      - isNull:
+          path: spec.template.spec.volumes[0].persistentVolumeClaim
+        documentIndex: 0
+
+  - it: service is ClusterIP on port 8080
+    asserts:
+      - isKind:
+          of: Service
+        documentIndex: 1
+      - equal:
+          path: spec.type
+          value: ClusterIP
+        documentIndex: 1
+      - equal:
+          path: spec.ports[0].port
+          value: 8080
+        documentIndex: 1
+
+  - it: readiness probe checks root path on http port
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: http
+        documentIndex: 0

--- a/helm/omcsi/tests/webapp_test.yaml
+++ b/helm/omcsi/tests/webapp_test.yaml
@@ -32,6 +32,20 @@ tests:
           pattern: "minecraft-wrapper-internal.*actuator/health"
         documentIndex: 0
 
+  - it: init container wget uses a connect/read timeout
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "wget -T"
+        documentIndex: 0
+
+  - it: init container exits non-zero after max attempts
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "exit 1"
+        documentIndex: 0
+
   - it: mounts mcserver and webapp-data volumes
     asserts:
       - contains:

--- a/helm/omcsi/values.yaml
+++ b/helm/omcsi/values.yaml
@@ -243,6 +243,15 @@ secrets:
   agentAnthropicApiKey: ""
 
 # ---------------------------------------------------------------------------
+# PodDisruptionBudgets
+# ---------------------------------------------------------------------------
+# When enabled, creates PDBs for minecraft-wrapper, webapp, and alert-manager
+# with minAvailable: 1.  Disable if your cluster has a single node and drain
+# operations would otherwise be blocked.
+podDisruptionBudgets:
+  enabled: true
+
+# ---------------------------------------------------------------------------
 # Persistence
 # ---------------------------------------------------------------------------
 persistence:

--- a/helm/omcsi/values.yaml
+++ b/helm/omcsi/values.yaml
@@ -29,7 +29,7 @@ minecraftWrapper:
   image:
     repository: dmccoystephenson/open-mc-server
     tag: latest
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
   # replicaCount is fixed at 1 — a single Minecraft server instance must own
   # the world data exclusively.  The value is hardcoded in the template.
   resources:
@@ -82,7 +82,7 @@ webapp:
   image:
     repository: dmccoystephenson/open-mc-server-webapp
     tag: latest
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
   replicaCount: 1
   resources:
     requests:
@@ -116,7 +116,7 @@ nginx:
   image:
     repository: dmccoystephenson/open-mc-server-nginx
     tag: latest
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
   replicaCount: 1
   resources:
     requests:
@@ -146,7 +146,7 @@ backupManager:
   image:
     repository: dmccoystephenson/open-mc-server-backup-manager
     tag: latest
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
   replicaCount: 1
   resources:
     requests:
@@ -176,7 +176,7 @@ alertManager:
   image:
     repository: dmccoystephenson/open-mc-server-alert-manager
     tag: latest
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
   replicaCount: 1
   resources:
     requests:
@@ -200,7 +200,7 @@ agentManager:
   image:
     repository: dmccoystephenson/open-mc-server-agent-manager
     tag: latest
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
   replicaCount: 1
   resources:
     requests:


### PR DESCRIPTION
Closes #143, #99, #150

## Changes

### Health probes — \`minecraft-wrapper\`, \`backup-manager\`, \`agent-manager\` (#143)

**\`minecraft-wrapper\`**
- \`startupProbe\` on \`/actuator/health\` (port 8092) with \`failureThreshold: 60\` × \`periodSeconds: 10\` = 10-minute window, covering Spigot's first-boot BuildTools compilation. Kubernetes will not start liveness checks until this succeeds.
- \`livenessProbe\` and \`readinessProbe\` take over once the wrapper is up.

**\`backup-manager\`**
- Added \`spring-boot-starter-actuator\` dependency so \`/actuator/health\` exists.
- \`livenessProbe\` and \`readinessProbe\` on \`/actuator/health\` (port 8091).

**\`agent-manager\`**
- Management endpoints moved to a dedicated port (8094) that binds on all interfaces (not just loopback) so the kubelet can reach \`/actuator/health\` for probes.
- \`livenessProbe\` and \`readinessProbe\` target the \`management\` named port (8094), not the main API port.

### Webapp startup ordering — \`webapp\` init container (#99)

Adds a \`wait-for-wrapper\` init container (busybox) that polls the minecraft-wrapper API before allowing the webapp to start. The loop uses \`wget -T 5\` for a per-attempt connect/read timeout and exits non-zero after 60 failed attempts (~5 minutes) with a clear error message, so a misconfigured wrapper doesn't hang the webapp in \`Init\` state indefinitely.

### PodDisruptionBudgets (#150)

New \`pdb.yaml\` template creates \`policy/v1\` PDBs with \`minAvailable: 1\` for \`minecraft-wrapper\`, \`webapp\`, and \`alert-manager\`. Gated behind \`podDisruptionBudgets.enabled\` (defaults \`true\`); set \`false\` on single-node clusters to avoid blocking drain operations.

### Helm unit tests + CI coverage

Seven \`helm-unittest\` test suites covering all Wave 1 resources plus baseline chart behavior (probes, init container, PDBs, PVCs). A new \`helm-unit-test\` CI job runs them on every push; the existing smoke-test job gained steps that verify PDBs, startup probe config, and the init container name against the live kind cluster.

### Other fixes

- \`imagePullPolicy: Always\` for all services — \`IfNotPresent\` with \`:latest\` tags means nodes silently use stale cached images after a rebuild.
- \`podDisruptionBudgets.enabled\` conditional uses \`ne "false" (toString ...)\` to be nil-safe under \`--reuse-values\` upgrades (Sprig \`default\` treats \`false\` as falsy and returns the default, making it impossible to opt out).
- helm-unittest pinned to \`v1.1.0\`; Helm in the unit-test job bumped to \`v3.20.0\` (required for \`platformHooks\` support in the plugin).

## Not included

**#93 (alert rate limiting)** requires changes to the \`alert-manager\` Java source — there is no env-var hook for rate limiting in the current application code. Left for a separate upstream PR.

## Verified on production cluster

Deployed to the Kingdom: First Era LKE cluster and confirmed:
- All 5 pods reach \`Running\`/\`Ready\`
- \`minecraft-wrapper\` startup probe passes (10-minute window)
- \`backup-manager\` \`/actuator/health\` returns 200 with actuator dependency added
- \`webapp\` init container \`wait-for-wrapper\` completes successfully
- 3 PDBs present with \`ALLOWED DISRUPTIONS: 0\` (correct for single-replica services)

## Test plan
- [x] CI Helm unit tests pass (57 tests across 7 suites)
- [x] CI Helm Deploy Smoke Test passes (PDB, probe, and init container assertions)
- [x] Deployed and verified on production LKE cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_