### PR TITLE
feat: optional Prometheus ServiceMonitors and Grafana dashboard (closes #152)

### DIFF
--- a/agent-manager/build.gradle
+++ b/agent-manager/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'net.dv8tion:JDA:5.0.0-beta.18'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/agent-manager/src/main/resources/application.properties
+++ b/agent-manager/src/main/resources/application.properties
@@ -51,7 +51,7 @@ diagnostics.webapp.enabled=${DIAGNOSTICS_WEBAPP_ENABLED:false}
 webapp.url=${WEBAPP_URL:http://webapp:8080}
 
 # Actuator configuration for health checks and dynamic log management
-management.endpoints.web.exposure.include=health,loggers
+management.endpoints.web.exposure.include=health,loggers,prometheus
 management.endpoint.health.show-details=always
 # Management endpoints run on a dedicated port (8094) so they can be separated
 # from the main API (8093) in Service routing. The address is not restricted to

--- a/alert-manager/build.gradle
+++ b/alert-manager/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'io.swagger.core.v3:swagger-annotations:2.2.19'
     compileOnly 'org.projectlombok:lombok'

--- a/alert-manager/src/main/resources/application.properties
+++ b/alert-manager/src/main/resources/application.properties
@@ -19,7 +19,7 @@ http.client.connect-timeout-seconds=5
 http.client.read-timeout-seconds=5
 
 # Actuator configuration for health checks
-management.endpoints.web.exposure.include=health
+management.endpoints.web.exposure.include=health,prometheus
 management.endpoint.health.show-details=always
 
 # Data storage configuration

--- a/backup-manager/build.gradle
+++ b/backup-manager/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'io.swagger.core.v3:swagger-annotations:2.2.19'
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'

--- a/backup-manager/src/main/resources/application.properties
+++ b/backup-manager/src/main/resources/application.properties
@@ -30,6 +30,10 @@ alerts.backup.failure=${ALERTS_BACKUP_FAILURE:true}
 spring.application.name=backup-manager
 server.port=${BACKUP_PORT:8091}
 
+# Actuator configuration
+management.endpoints.web.exposure.include=health,prometheus
+management.endpoint.health.show-details=always
+
 # Logging configuration
 logging.level.com.openmc.backupmanager=INFO
 logging.pattern.console=%d{yyyy-MM-dd HH:mm:ss} - %msg%n

--- a/docs/KUBERNETES_IMPROVEMENTS.md
+++ b/docs/KUBERNETES_IMPROVEMENTS.md
@@ -138,16 +138,33 @@ All three PDBs use `policy/v1` (stable since Kubernetes 1.21).
 
 ---
 
-## 11. Monitoring and Observability
+## 11. ~~Monitoring and Observability~~ ✅ Resolved
 
-**Problem:** No Prometheus `ServiceMonitor` or Grafana dashboard templates are included. Operators must manually configure monitoring.
+**Problem:** No Prometheus `ServiceMonitor` or Grafana dashboard templates were included. Operators had to manually configure monitoring.
 
-**Suggested improvements:**
-- Add optional `ServiceMonitor` templates for services that expose Prometheus metrics (Spring Boot actuator endpoints).
-- Include a sample Grafana dashboard JSON for Minecraft server metrics (TPS, player count, memory usage).
-- Document integration with the Prometheus Operator / kube-prometheus-stack.
-
-**Priority:** Low — nice-to-have for production; OMCSI's webapp already provides basic resource metrics.
+**Implemented in PR #157:**
+- Added `monitoring.enabled` gate (defaults to `false`) in `values.yaml`.
+- When enabled, one `ServiceMonitor` is created per service targeting Spring Boot Actuator's `/actuator/prometheus` endpoint:
+  - `minecraft-wrapper` — internal service, `wrapper` port (8092)
+  - `webapp` — `http` port (8080)
+  - `alert-manager` — `http` port (8090)
+  - `backup-manager` — `http` port (8091)
+  - `agent-manager` — `management` port (8094), only when `agentManager.enabled: true`
+- Each scraped service gains an `omcsi.io/metrics: "true"` label so the `ServiceMonitor` selector avoids the external minecraft-wrapper NodePort (game port only).
+- Agent-manager's management port 8094 is now also exposed in its `Service` spec.
+- A sample Grafana dashboard ConfigMap (`monitoring.grafanaDashboard.enabled`, default `true` when monitoring is on) is created with panels for service uptime, JVM heap, HTTP request rate/latency, CPU usage, and GC pause time.
+- `monitoring.serviceMonitor.labels` and `monitoring.grafanaDashboard.labels` allow operators to match their Prometheus Operator's `serviceMonitorSelector` and Grafana sidecar label, e.g.:
+  ```yaml
+  monitoring:
+    enabled: true
+    serviceMonitor:
+      labels:
+        release: kube-prometheus-stack
+    grafanaDashboard:
+      labels:
+        grafana_dashboard: "1"
+  ```
+- Requires the Prometheus Operator (e.g., `kube-prometheus-stack`) to be installed in the cluster.
 
 ---
 
@@ -165,4 +182,4 @@ All three PDBs use `policy/v1` (stable since Kubernetes 1.21).
 | 8 | ~~Network policies~~ ✅ Resolved | ~~Low~~ | ~~Medium~~ |
 | 9 | ~~Pod Disruption Budgets~~ ✅ Resolved | ~~Low~~ | ~~Low~~ |
 | 10 | Helm chart publishing | Low | Low |
-| 11 | Monitoring and observability | Low | Medium |
+| 11 | ~~Monitoring and observability~~ ✅ Resolved | ~~Low~~ | ~~Medium~~ |

--- a/helm/omcsi/files/grafana-dashboard.json
+++ b/helm/omcsi/files/grafana-dashboard.json
@@ -1,52 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "Prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "9.0.0"
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "gauge",
-      "name": "Gauge",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "graph",
-      "name": "Graph",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "stat",
-      "name": "Stat",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "timeseries",
-      "name": "Time series",
-      "version": ""
-    }
-  ],
   "annotations": {
     "list": []
   },
@@ -65,7 +17,7 @@
       "type": "row"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
@@ -81,7 +33,7 @@
       "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "center", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
           "expr": "up{job=~\".*minecraft-wrapper.*\"}",
           "legendFormat": "minecraft-wrapper"
         }
@@ -90,7 +42,7 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
@@ -106,7 +58,7 @@
       "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "center", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
           "expr": "up{job=~\".*webapp.*\"}",
           "legendFormat": "webapp"
         }
@@ -115,7 +67,7 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
@@ -131,7 +83,7 @@
       "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "center", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
           "expr": "up{job=~\".*alert-manager.*\"}",
           "legendFormat": "alert-manager"
         }
@@ -140,7 +92,7 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
@@ -156,7 +108,7 @@
       "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "center", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
           "expr": "up{job=~\".*backup-manager.*\"}",
           "legendFormat": "backup-manager"
         }
@@ -172,7 +124,7 @@
       "type": "row"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "palette-classic" },
@@ -186,21 +138,21 @@
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
           "expr": "jvm_memory_used_bytes{job=~\"$service\", area=\"heap\"}",
-          "legendFormat": "{{instance}} heap used"
+          "legendFormat": "{{job}} heap used"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
           "expr": "jvm_memory_max_bytes{job=~\"$service\", area=\"heap\"}",
-          "legendFormat": "{{instance}} heap max"
+          "legendFormat": "{{job}} heap max"
         }
       ],
       "title": "JVM Heap Memory",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "palette-classic" },
@@ -214,14 +166,14 @@
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
           "expr": "jvm_threads_live_threads{job=~\"$service\"}",
-          "legendFormat": "{{instance}} live threads"
+          "legendFormat": "{{job}} live threads"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
           "expr": "jvm_threads_daemon_threads{job=~\"$service\"}",
-          "legendFormat": "{{instance}} daemon threads"
+          "legendFormat": "{{job}} daemon threads"
         }
       ],
       "title": "JVM Threads",
@@ -235,7 +187,7 @@
       "type": "row"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "palette-classic" },
@@ -249,16 +201,16 @@
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
           "expr": "rate(http_server_requests_seconds_count{job=~\"$service\"}[2m])",
-          "legendFormat": "{{instance}} {{method}} {{uri}} {{status}}"
+          "legendFormat": "{{job}} {{method}} {{uri}} {{status}}"
         }
       ],
       "title": "HTTP Request Rate",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "palette-classic" },
@@ -272,9 +224,9 @@
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
           "expr": "rate(http_server_requests_seconds_sum{job=~\"$service\"}[2m]) / rate(http_server_requests_seconds_count{job=~\"$service\"}[2m])",
-          "legendFormat": "{{instance}} {{method}} {{uri}} avg latency"
+          "legendFormat": "{{job}} {{method}} {{uri}} avg latency"
         }
       ],
       "title": "HTTP Request Latency (avg)",
@@ -288,7 +240,7 @@
       "type": "row"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "palette-classic" },
@@ -302,16 +254,16 @@
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
           "expr": "process_cpu_usage{job=~\"$service\"}",
-          "legendFormat": "{{instance}} CPU"
+          "legendFormat": "{{job}} CPU"
         }
       ],
       "title": "Process CPU Usage",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "palette-classic" },
@@ -325,9 +277,9 @@
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
           "expr": "rate(jvm_gc_pause_seconds_sum{job=~\"$service\"}[2m])",
-          "legendFormat": "{{instance}} {{action}} {{cause}}"
+          "legendFormat": "{{job}} {{action}} {{cause}}"
         }
       ],
       "title": "GC Pause Time Rate",
@@ -341,7 +293,7 @@
     "list": [
       {
         "current": {},
-        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
         "definition": "label_values(up, job)",
         "hide": 0,
         "includeAll": true,

--- a/helm/omcsi/files/grafana-dashboard.json
+++ b/helm/omcsi/files/grafana-dashboard.json
@@ -2,7 +2,7 @@
   "annotations": {
     "list": []
   },
-  "description": "OMCSI – Open Minecraft Server Infrastructure overview. Covers JVM memory, HTTP request rates, and per-service uptime for all Spring Boot services.",
+  "description": "OMCSI – Open Minecraft Server Infrastructure overview. Covers per-service uptime (minecraft-wrapper, webapp, alert-manager, backup-manager, agent-manager), JVM memory and threads, HTTP request rates and latency, CPU usage, and GC pause time.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -114,6 +114,31 @@
         }
       ],
       "title": "backup-manager",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            { "options": { "0": { "color": "red", "text": "DOWN" }, "1": { "color": "green", "text": "UP" } }, "type": "value" }
+          ],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "green", "value": 1 }] }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
+      "id": 6,
+      "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "center", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "up{job=~\".*agent-manager.*\"}",
+          "legendFormat": "agent-manager"
+        }
+      ],
+      "title": "agent-manager",
       "type": "stat"
     },
     {

--- a/helm/omcsi/files/grafana-dashboard.json
+++ b/helm/omcsi/files/grafana-dashboard.json
@@ -1,0 +1,366 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "9.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "gauge",
+      "name": "Gauge",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "description": "OMCSI – Open Minecraft Server Infrastructure overview. Covers JVM memory, HTTP request rates, and per-service uptime for all Spring Boot services.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            { "options": { "0": { "color": "red", "text": "DOWN" }, "1": { "color": "green", "text": "UP" } }, "type": "value" }
+          ],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "green", "value": 1 }] }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
+      "id": 2,
+      "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "center", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "up{job=~\".*minecraft-wrapper.*\"}",
+          "legendFormat": "minecraft-wrapper"
+        }
+      ],
+      "title": "minecraft-wrapper",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            { "options": { "0": { "color": "red", "text": "DOWN" }, "1": { "color": "green", "text": "UP" } }, "type": "value" }
+          ],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "green", "value": 1 }] }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
+      "id": 3,
+      "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "center", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "up{job=~\".*webapp.*\"}",
+          "legendFormat": "webapp"
+        }
+      ],
+      "title": "webapp",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            { "options": { "0": { "color": "red", "text": "DOWN" }, "1": { "color": "green", "text": "UP" } }, "type": "value" }
+          ],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "green", "value": 1 }] }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
+      "id": 4,
+      "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "center", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "up{job=~\".*alert-manager.*\"}",
+          "legendFormat": "alert-manager"
+        }
+      ],
+      "title": "alert-manager",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            { "options": { "0": { "color": "red", "text": "DOWN" }, "1": { "color": "green", "text": "UP" } }, "type": "value" }
+          ],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "green", "value": 1 }] }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
+      "id": 5,
+      "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "center", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "up{job=~\".*backup-manager.*\"}",
+          "legendFormat": "backup-manager"
+        }
+      ],
+      "title": "backup-manager",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "id": 10,
+      "title": "JVM Memory",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 1, "fillOpacity": 10 },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "id": 11,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "jvm_memory_used_bytes{job=~\"$service\", area=\"heap\"}",
+          "legendFormat": "{{instance}} heap used"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "jvm_memory_max_bytes{job=~\"$service\", area=\"heap\"}",
+          "legendFormat": "{{instance}} heap max"
+        }
+      ],
+      "title": "JVM Heap Memory",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 1, "fillOpacity": 10 },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "id": 12,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "jvm_threads_live_threads{job=~\"$service\"}",
+          "legendFormat": "{{instance}} live threads"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "jvm_threads_daemon_threads{job=~\"$service\"}",
+          "legendFormat": "{{instance}} daemon threads"
+        }
+      ],
+      "title": "JVM Threads",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
+      "id": 20,
+      "title": "HTTP Requests",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 1, "fillOpacity": 10 },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 15 },
+      "id": 21,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(http_server_requests_seconds_count{job=~\"$service\"}[2m])",
+          "legendFormat": "{{instance}} {{method}} {{uri}} {{status}}"
+        }
+      ],
+      "title": "HTTP Request Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 1, "fillOpacity": 10 },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 15 },
+      "id": 22,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(http_server_requests_seconds_sum{job=~\"$service\"}[2m]) / rate(http_server_requests_seconds_count{job=~\"$service\"}[2m])",
+          "legendFormat": "{{instance}} {{method}} {{uri}} avg latency"
+        }
+      ],
+      "title": "HTTP Request Latency (avg)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 },
+      "id": 30,
+      "title": "Process & GC",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 1, "fillOpacity": 10 },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "id": 31,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "process_cpu_usage{job=~\"$service\"}",
+          "legendFormat": "{{instance}} CPU"
+        }
+      ],
+      "title": "Process CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 1, "fillOpacity": 10 },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "id": 32,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(jvm_gc_pause_seconds_sum{job=~\"$service\"}[2m])",
+          "legendFormat": "{{instance}} {{action}} {{cause}}"
+        }
+      ],
+      "title": "GC Pause Time Rate",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 37,
+  "tags": ["omcsi", "minecraft"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "definition": "label_values(up, job)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Service",
+        "multi": true,
+        "name": "service",
+        "options": [],
+        "query": { "query": "label_values(up, job)", "refId": "StandardVariableQuery" },
+        "refresh": 2,
+        "regex": ".*omcsi.*",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "OMCSI – Minecraft Server Infrastructure",
+  "uid": "omcsi-overview",
+  "version": 1
+}

--- a/helm/omcsi/templates/agent-manager.yaml
+++ b/helm/omcsi/templates/agent-manager.yaml
@@ -112,7 +112,7 @@ metadata:
   labels:
     {{- include "omcsi.labels" . | nindent 4 }}
     {{- include "omcsi.selectorLabels" (dict "root" . "component" "agent-manager") | nindent 4 }}
-    {{- if .Values.monitoring.enabled }}
+    {{- if ne "false" (toString ((.Values.monitoring).enabled)) }}
     omcsi.io/metrics: "true"
     {{- end }}
 spec:

--- a/helm/omcsi/templates/agent-manager.yaml
+++ b/helm/omcsi/templates/agent-manager.yaml
@@ -112,6 +112,9 @@ metadata:
   labels:
     {{- include "omcsi.labels" . | nindent 4 }}
     {{- include "omcsi.selectorLabels" (dict "root" . "component" "agent-manager") | nindent 4 }}
+    {{- if .Values.monitoring.enabled }}
+    omcsi.io/metrics: "true"
+    {{- end }}
 spec:
   type: {{ .Values.agentManager.service.type }}
   ports:
@@ -119,6 +122,10 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    - port: 8094
+      targetPort: management
+      protocol: TCP
+      name: management
   selector:
     {{- include "omcsi.selectorLabels" (dict "root" . "component" "agent-manager") | nindent 4 }}
 {{- end }}

--- a/helm/omcsi/templates/alert-manager.yaml
+++ b/helm/omcsi/templates/alert-manager.yaml
@@ -94,6 +94,9 @@ metadata:
   labels:
     {{- include "omcsi.labels" . | nindent 4 }}
     {{- include "omcsi.selectorLabels" (dict "root" . "component" "alert-manager") | nindent 4 }}
+    {{- if .Values.monitoring.enabled }}
+    omcsi.io/metrics: "true"
+    {{- end }}
 spec:
   type: {{ .Values.alertManager.service.type }}
   ports:

--- a/helm/omcsi/templates/alert-manager.yaml
+++ b/helm/omcsi/templates/alert-manager.yaml
@@ -94,7 +94,7 @@ metadata:
   labels:
     {{- include "omcsi.labels" . | nindent 4 }}
     {{- include "omcsi.selectorLabels" (dict "root" . "component" "alert-manager") | nindent 4 }}
-    {{- if .Values.monitoring.enabled }}
+    {{- if ne "false" (toString ((.Values.monitoring).enabled)) }}
     omcsi.io/metrics: "true"
     {{- end }}
 spec:

--- a/helm/omcsi/templates/backup-manager.yaml
+++ b/helm/omcsi/templates/backup-manager.yaml
@@ -108,6 +108,9 @@ metadata:
   labels:
     {{- include "omcsi.labels" . | nindent 4 }}
     {{- include "omcsi.selectorLabels" (dict "root" . "component" "backup-manager") | nindent 4 }}
+    {{- if .Values.monitoring.enabled }}
+    omcsi.io/metrics: "true"
+    {{- end }}
 spec:
   type: {{ .Values.backupManager.service.type }}
   ports:

--- a/helm/omcsi/templates/backup-manager.yaml
+++ b/helm/omcsi/templates/backup-manager.yaml
@@ -108,7 +108,7 @@ metadata:
   labels:
     {{- include "omcsi.labels" . | nindent 4 }}
     {{- include "omcsi.selectorLabels" (dict "root" . "component" "backup-manager") | nindent 4 }}
-    {{- if .Values.monitoring.enabled }}
+    {{- if ne "false" (toString ((.Values.monitoring).enabled)) }}
     omcsi.io/metrics: "true"
     {{- end }}
 spec:

--- a/helm/omcsi/templates/grafana-dashboard.yaml
+++ b/helm/omcsi/templates/grafana-dashboard.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.monitoring.enabled .Values.monitoring.grafanaDashboard.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "omcsi.fullname" . }}-grafana-dashboard
+  labels:
+    {{- include "omcsi.labels" . | nindent 4 }}
+    {{- with .Values.monitoring.grafanaDashboard.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+data:
+  omcsi-dashboard.json: |-
+    {{- .Files.Get "files/grafana-dashboard.json" | nindent 4 }}
+{{- end }}

--- a/helm/omcsi/templates/grafana-dashboard.yaml
+++ b/helm/omcsi/templates/grafana-dashboard.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.monitoring.enabled .Values.monitoring.grafanaDashboard.enabled }}
+{{- if and (ne "false" (toString ((.Values.monitoring).enabled))) (ne "false" (toString ((.Values.monitoring).grafanaDashboard).enabled)) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/omcsi/templates/minecraft-wrapper.yaml
+++ b/helm/omcsi/templates/minecraft-wrapper.yaml
@@ -180,7 +180,7 @@ metadata:
   labels:
     {{- include "omcsi.labels" . | nindent 4 }}
     {{- include "omcsi.selectorLabels" (dict "root" . "component" "minecraft-wrapper") | nindent 4 }}
-    {{- if .Values.monitoring.enabled }}
+    {{- if ne "false" (toString ((.Values.monitoring).enabled)) }}
     omcsi.io/metrics: "true"
     {{- end }}
 spec:

--- a/helm/omcsi/templates/minecraft-wrapper.yaml
+++ b/helm/omcsi/templates/minecraft-wrapper.yaml
@@ -180,6 +180,9 @@ metadata:
   labels:
     {{- include "omcsi.labels" . | nindent 4 }}
     {{- include "omcsi.selectorLabels" (dict "root" . "component" "minecraft-wrapper") | nindent 4 }}
+    {{- if .Values.monitoring.enabled }}
+    omcsi.io/metrics: "true"
+    {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/helm/omcsi/templates/networkpolicies.yaml
+++ b/helm/omcsi/templates/networkpolicies.yaml
@@ -48,7 +48,7 @@ spec:
         - ipBlock:
             cidr: {{ ((.Values.networkPolicy).kubeNodeCIDR) | default "0.0.0.0/0" | quote }}
     # Prometheus scrape of wrapper actuator metrics (cross-namespace)
-    {{- if .Values.monitoring.enabled }}
+    {{- if ne "false" (toString ((.Values.monitoring).enabled)) }}
     - ports:
         - port: {{ .Values.minecraftWrapper.internalService.wrapperPort }}
           protocol: TCP
@@ -136,7 +136,7 @@ spec:
         - ipBlock:
             cidr: {{ ((.Values.networkPolicy).kubeNodeCIDR) | default "0.0.0.0/0" | quote }}
     # Prometheus scrape of webapp actuator metrics (cross-namespace)
-    {{- if .Values.monitoring.enabled }}
+    {{- if ne "false" (toString ((.Values.monitoring).enabled)) }}
     - ports:
         - port: 8080
           protocol: TCP
@@ -254,7 +254,7 @@ spec:
         - ipBlock:
             cidr: {{ ((.Values.networkPolicy).kubeNodeCIDR) | default "0.0.0.0/0" | quote }}
     # Prometheus scrape of backup-manager actuator metrics (cross-namespace)
-    {{- if .Values.monitoring.enabled }}
+    {{- if ne "false" (toString ((.Values.monitoring).enabled)) }}
     - ports:
         - port: {{ .Values.backupManager.service.port }}
           protocol: TCP
@@ -324,7 +324,7 @@ spec:
         - ipBlock:
             cidr: {{ ((.Values.networkPolicy).kubeNodeCIDR) | default "0.0.0.0/0" | quote }}
     # Prometheus scrape of alert-manager actuator metrics (cross-namespace)
-    {{- if .Values.monitoring.enabled }}
+    {{- if ne "false" (toString ((.Values.monitoring).enabled)) }}
     - ports:
         - port: {{ .Values.alertManager.service.port }}
           protocol: TCP
@@ -382,15 +382,15 @@ spec:
       {{- include "omcsi.selectorLabels" (dict "root" . "component" "agent-manager") | nindent 6 }}
   policyTypes: [Ingress, Egress]
   ingress:
-    # Management/health probe port (8094) for kubelet probes
+    # Management/health probe port (8094) — kubelet probes
     - ports:
         - port: 8094
           protocol: TCP
       from:
         - ipBlock:
-            cidr: 0.0.0.0/0
+            cidr: {{ ((.Values.networkPolicy).kubeNodeCIDR) | default "0.0.0.0/0" | quote }}
     # Prometheus scrape of agent-manager actuator metrics (cross-namespace)
-    {{- if .Values.monitoring.enabled }}
+    {{- if ne "false" (toString ((.Values.monitoring).enabled)) }}
     - ports:
         - port: 8094
           protocol: TCP

--- a/helm/omcsi/templates/networkpolicies.yaml
+++ b/helm/omcsi/templates/networkpolicies.yaml
@@ -47,6 +47,19 @@ spec:
               {{- include "omcsi.selectorLabels" (dict "root" . "component" "agent-manager") | nindent 14 }}
         - ipBlock:
             cidr: {{ ((.Values.networkPolicy).kubeNodeCIDR) | default "0.0.0.0/0" | quote }}
+    # Prometheus scrape of wrapper actuator metrics (cross-namespace)
+    {{- if .Values.monitoring.enabled }}
+    - ports:
+        - port: {{ .Values.minecraftWrapper.internalService.wrapperPort }}
+          protocol: TCP
+      from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.monitoring.prometheusNamespace | quote }}
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+    {{- end }}
     # BlueMap traffic from nginx
     - ports:
         - port: 8100
@@ -122,6 +135,19 @@ spec:
               {{- include "omcsi.selectorLabels" (dict "root" . "component" "nginx") | nindent 14 }}
         - ipBlock:
             cidr: {{ ((.Values.networkPolicy).kubeNodeCIDR) | default "0.0.0.0/0" | quote }}
+    # Prometheus scrape of webapp actuator metrics (cross-namespace)
+    {{- if .Values.monitoring.enabled }}
+    - ports:
+        - port: 8080
+          protocol: TCP
+      from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.monitoring.prometheusNamespace | quote }}
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+    {{- end }}
   egress:
     # Minecraft wrapper API and RCON
     - ports:
@@ -227,6 +253,19 @@ spec:
               {{- include "omcsi.selectorLabels" (dict "root" . "component" "agent-manager") | nindent 14 }}
         - ipBlock:
             cidr: {{ ((.Values.networkPolicy).kubeNodeCIDR) | default "0.0.0.0/0" | quote }}
+    # Prometheus scrape of backup-manager actuator metrics (cross-namespace)
+    {{- if .Values.monitoring.enabled }}
+    - ports:
+        - port: {{ .Values.backupManager.service.port }}
+          protocol: TCP
+      from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.monitoring.prometheusNamespace | quote }}
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+    {{- end }}
   egress:
     # Alert notifications
     - ports:
@@ -284,6 +323,19 @@ spec:
               {{- include "omcsi.selectorLabels" (dict "root" . "component" "agent-manager") | nindent 14 }}
         - ipBlock:
             cidr: {{ ((.Values.networkPolicy).kubeNodeCIDR) | default "0.0.0.0/0" | quote }}
+    # Prometheus scrape of alert-manager actuator metrics (cross-namespace)
+    {{- if .Values.monitoring.enabled }}
+    - ports:
+        - port: {{ .Values.alertManager.service.port }}
+          protocol: TCP
+      from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.monitoring.prometheusNamespace | quote }}
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+    {{- end }}
   egress:
     # RCON for in-game broadcast messages
     - ports:
@@ -337,6 +389,19 @@ spec:
       from:
         - ipBlock:
             cidr: 0.0.0.0/0
+    # Prometheus scrape of agent-manager actuator metrics (cross-namespace)
+    {{- if .Values.monitoring.enabled }}
+    - ports:
+        - port: 8094
+          protocol: TCP
+      from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.monitoring.prometheusNamespace | quote }}
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+    {{- end }}
   egress:
     # Minecraft wrapper API
     - ports:

--- a/helm/omcsi/templates/servicemonitors.yaml
+++ b/helm/omcsi/templates/servicemonitors.yaml
@@ -1,0 +1,124 @@
+{{- if .Values.monitoring.enabled }}
+# ServiceMonitors tell the Prometheus Operator which services to scrape.
+# Each service must expose Spring Boot Actuator at /actuator/prometheus on the
+# port named below.  Only services with the omcsi.io/metrics: "true" label are
+# targeted so that the external minecraft-wrapper Service (game port only) is
+# not accidentally scraped.
+
+# ---------------------------------------------------------------------------
+# minecraft-wrapper – internal service (wrapper port 8092)
+# ---------------------------------------------------------------------------
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "omcsi.fullname" . }}-minecraft-wrapper
+  labels:
+    {{- include "omcsi.labels" . | nindent 4 }}
+    {{- with .Values.monitoring.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      omcsi.io/metrics: "true"
+      {{- include "omcsi.selectorLabels" (dict "root" . "component" "minecraft-wrapper") | nindent 6 }}
+  endpoints:
+    - port: wrapper
+      path: /actuator/prometheus
+      interval: {{ .Values.monitoring.serviceMonitor.interval | quote }}
+      scrapeTimeout: {{ .Values.monitoring.serviceMonitor.scrapeTimeout | quote }}
+---
+# ---------------------------------------------------------------------------
+# webapp – http port 8080
+# ---------------------------------------------------------------------------
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "omcsi.fullname" . }}-webapp
+  labels:
+    {{- include "omcsi.labels" . | nindent 4 }}
+    {{- with .Values.monitoring.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      omcsi.io/metrics: "true"
+      {{- include "omcsi.selectorLabels" (dict "root" . "component" "webapp") | nindent 6 }}
+  endpoints:
+    - port: http
+      path: /actuator/prometheus
+      interval: {{ .Values.monitoring.serviceMonitor.interval | quote }}
+      scrapeTimeout: {{ .Values.monitoring.serviceMonitor.scrapeTimeout | quote }}
+---
+# ---------------------------------------------------------------------------
+# alert-manager – http port 8090
+# ---------------------------------------------------------------------------
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "omcsi.fullname" . }}-alert-manager
+  labels:
+    {{- include "omcsi.labels" . | nindent 4 }}
+    {{- with .Values.monitoring.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      omcsi.io/metrics: "true"
+      {{- include "omcsi.selectorLabels" (dict "root" . "component" "alert-manager") | nindent 6 }}
+  endpoints:
+    - port: http
+      path: /actuator/prometheus
+      interval: {{ .Values.monitoring.serviceMonitor.interval | quote }}
+      scrapeTimeout: {{ .Values.monitoring.serviceMonitor.scrapeTimeout | quote }}
+---
+# ---------------------------------------------------------------------------
+# backup-manager – http port 8091
+# ---------------------------------------------------------------------------
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "omcsi.fullname" . }}-backup-manager
+  labels:
+    {{- include "omcsi.labels" . | nindent 4 }}
+    {{- with .Values.monitoring.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      omcsi.io/metrics: "true"
+      {{- include "omcsi.selectorLabels" (dict "root" . "component" "backup-manager") | nindent 6 }}
+  endpoints:
+    - port: http
+      path: /actuator/prometheus
+      interval: {{ .Values.monitoring.serviceMonitor.interval | quote }}
+      scrapeTimeout: {{ .Values.monitoring.serviceMonitor.scrapeTimeout | quote }}
+---
+# ---------------------------------------------------------------------------
+# agent-manager – management port 8094 (only when agent-manager is enabled)
+# ---------------------------------------------------------------------------
+{{- if .Values.agentManager.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "omcsi.fullname" . }}-agent-manager
+  labels:
+    {{- include "omcsi.labels" . | nindent 4 }}
+    {{- with .Values.monitoring.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      omcsi.io/metrics: "true"
+      {{- include "omcsi.selectorLabels" (dict "root" . "component" "agent-manager") | nindent 6 }}
+  endpoints:
+    - port: management
+      path: /actuator/prometheus
+      interval: {{ .Values.monitoring.serviceMonitor.interval | quote }}
+      scrapeTimeout: {{ .Values.monitoring.serviceMonitor.scrapeTimeout | quote }}
+{{- end }}
+{{- end }}

--- a/helm/omcsi/templates/servicemonitors.yaml
+++ b/helm/omcsi/templates/servicemonitors.yaml
@@ -1,4 +1,7 @@
-{{- if .Values.monitoring.enabled }}
+{{- if ne "false" (toString ((.Values.monitoring).enabled)) }}
+{{- if not (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+{{- fail "monitoring.enabled=true requires the Prometheus Operator CRDs. Install kube-prometheus-stack or the standalone Prometheus Operator before enabling monitoring." }}
+{{- end }}
 # ServiceMonitors tell the Prometheus Operator which services to scrape.
 # Each service must expose Spring Boot Actuator at /actuator/prometheus on the
 # port named below.  Only services with the omcsi.io/metrics: "true" label are
@@ -100,7 +103,7 @@ spec:
 # ---------------------------------------------------------------------------
 # agent-manager – management port 8094 (only when agent-manager is enabled)
 # ---------------------------------------------------------------------------
-{{- if .Values.agentManager.enabled }}
+{{- if ne "false" (toString ((.Values.agentManager).enabled)) }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/helm/omcsi/templates/webapp.yaml
+++ b/helm/omcsi/templates/webapp.yaml
@@ -161,7 +161,7 @@ metadata:
   labels:
     {{- include "omcsi.labels" . | nindent 4 }}
     {{- include "omcsi.selectorLabels" (dict "root" . "component" "webapp") | nindent 4 }}
-    {{- if .Values.monitoring.enabled }}
+    {{- if ne "false" (toString ((.Values.monitoring).enabled)) }}
     omcsi.io/metrics: "true"
     {{- end }}
 spec:

--- a/helm/omcsi/templates/webapp.yaml
+++ b/helm/omcsi/templates/webapp.yaml
@@ -161,6 +161,9 @@ metadata:
   labels:
     {{- include "omcsi.labels" . | nindent 4 }}
     {{- include "omcsi.selectorLabels" (dict "root" . "component" "webapp") | nindent 4 }}
+    {{- if .Values.monitoring.enabled }}
+    omcsi.io/metrics: "true"
+    {{- end }}
 spec:
   type: {{ .Values.webapp.service.type }}
   ports:

--- a/helm/omcsi/tests/monitoring_test.yaml
+++ b/helm/omcsi/tests/monitoring_test.yaml
@@ -1,4 +1,7 @@
 suite: monitoring
+capabilities:
+  apiVersions:
+    - monitoring.coreos.com/v1
 set:
   secrets.rconPassword: ci
   secrets.adminPassword: ci

--- a/helm/omcsi/tests/monitoring_test.yaml
+++ b/helm/omcsi/tests/monitoring_test.yaml
@@ -1,0 +1,234 @@
+suite: monitoring
+set:
+  secrets.rconPassword: ci
+  secrets.adminPassword: ci
+  monitoring.enabled: true
+  monitoring.serviceMonitor.labels:
+    release: kube-prometheus-stack
+  monitoring.grafanaDashboard.labels:
+    grafana_dashboard: "1"
+tests:
+  # -------------------------------------------------------------------------
+  # ServiceMonitors created when monitoring.enabled = true
+  # -------------------------------------------------------------------------
+  - it: minecraft-wrapper ServiceMonitor is created
+    templates:
+      - templates/servicemonitors.yaml
+    asserts:
+      - isKind:
+          of: ServiceMonitor
+        documentIndex: 0
+      - equal:
+          path: spec.endpoints[0].port
+          value: wrapper
+        documentIndex: 0
+      - equal:
+          path: spec.endpoints[0].path
+          value: /actuator/prometheus
+        documentIndex: 0
+      - equal:
+          path: spec.endpoints[0].interval
+          value: "30s"
+        documentIndex: 0
+      - equal:
+          path: spec.endpoints[0].scrapeTimeout
+          value: "10s"
+        documentIndex: 0
+
+  - it: webapp ServiceMonitor is created
+    templates:
+      - templates/servicemonitors.yaml
+    asserts:
+      - isKind:
+          of: ServiceMonitor
+        documentIndex: 1
+      - equal:
+          path: spec.endpoints[0].port
+          value: http
+        documentIndex: 1
+      - equal:
+          path: spec.endpoints[0].path
+          value: /actuator/prometheus
+        documentIndex: 1
+
+  - it: alert-manager ServiceMonitor is created
+    templates:
+      - templates/servicemonitors.yaml
+    asserts:
+      - isKind:
+          of: ServiceMonitor
+        documentIndex: 2
+      - equal:
+          path: spec.endpoints[0].port
+          value: http
+        documentIndex: 2
+
+  - it: backup-manager ServiceMonitor is created
+    templates:
+      - templates/servicemonitors.yaml
+    asserts:
+      - isKind:
+          of: ServiceMonitor
+        documentIndex: 3
+      - equal:
+          path: spec.endpoints[0].port
+          value: http
+        documentIndex: 3
+
+  - it: ServiceMonitor has user-supplied extra labels
+    templates:
+      - templates/servicemonitors.yaml
+    asserts:
+      - equal:
+          path: metadata.labels["release"]
+          value: kube-prometheus-stack
+        documentIndex: 0
+
+  # -------------------------------------------------------------------------
+  # agent-manager ServiceMonitor only when agentManager.enabled = true
+  # -------------------------------------------------------------------------
+  - it: agent-manager ServiceMonitor is NOT created when agentManager disabled
+    templates:
+      - templates/servicemonitors.yaml
+    asserts:
+      - hasDocuments:
+          count: 4
+
+  - it: agent-manager ServiceMonitor uses management port
+    set:
+      agentManager.enabled: true
+      secrets.agentDiscordBotToken: ci-token
+      secrets.agentDiscordChannelId: "123456"
+      secrets.agentAnthropicApiKey: ci-key
+    templates:
+      - templates/servicemonitors.yaml
+    asserts:
+      - hasDocuments:
+          count: 5
+      - equal:
+          path: spec.endpoints[0].port
+          value: management
+        documentIndex: 4
+
+  # -------------------------------------------------------------------------
+  # omcsi.io/metrics label on services
+  # -------------------------------------------------------------------------
+  - it: internal minecraft-wrapper service has metrics label when monitoring enabled
+    templates:
+      - templates/minecraft-wrapper.yaml
+    asserts:
+      - equal:
+          path: metadata.labels["omcsi.io/metrics"]
+          value: "true"
+        documentIndex: 2
+
+  - it: webapp service has metrics label when monitoring enabled
+    templates:
+      - templates/webapp.yaml
+    asserts:
+      - equal:
+          path: metadata.labels["omcsi.io/metrics"]
+          value: "true"
+        documentIndex: 1
+
+  - it: alert-manager service has metrics label when monitoring enabled
+    templates:
+      - templates/alert-manager.yaml
+    asserts:
+      - equal:
+          path: metadata.labels["omcsi.io/metrics"]
+          value: "true"
+        documentIndex: 1
+
+  - it: backup-manager service has metrics label when monitoring enabled
+    templates:
+      - templates/backup-manager.yaml
+    asserts:
+      - equal:
+          path: metadata.labels["omcsi.io/metrics"]
+          value: "true"
+        documentIndex: 1
+
+  # -------------------------------------------------------------------------
+  # Nothing created when monitoring.enabled = false
+  # -------------------------------------------------------------------------
+  - it: no ServiceMonitors when monitoring disabled
+    set:
+      monitoring.enabled: false
+    templates:
+      - templates/servicemonitors.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: no Grafana dashboard ConfigMap when monitoring disabled
+    set:
+      monitoring.enabled: false
+    templates:
+      - templates/grafana-dashboard.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: no metrics label on webapp service when monitoring disabled
+    set:
+      monitoring.enabled: false
+    templates:
+      - templates/webapp.yaml
+    asserts:
+      - isNull:
+          path: metadata.labels["omcsi.io/metrics"]
+        documentIndex: 1
+
+  # -------------------------------------------------------------------------
+  # Grafana dashboard ConfigMap
+  # -------------------------------------------------------------------------
+  - it: Grafana dashboard ConfigMap is created when monitoring enabled
+    templates:
+      - templates/grafana-dashboard.yaml
+    asserts:
+      - isKind:
+          of: ConfigMap
+        documentIndex: 0
+      - isNotNull:
+          path: data["omcsi-dashboard.json"]
+        documentIndex: 0
+
+  - it: Grafana dashboard ConfigMap has user-supplied extra labels
+    templates:
+      - templates/grafana-dashboard.yaml
+    asserts:
+      - equal:
+          path: metadata.labels["grafana_dashboard"]
+          value: "1"
+        documentIndex: 0
+
+  - it: Grafana dashboard ConfigMap skipped when grafanaDashboard disabled
+    set:
+      monitoring.grafanaDashboard.enabled: false
+    templates:
+      - templates/grafana-dashboard.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # -------------------------------------------------------------------------
+  # agent-manager Service exposes management port 8094
+  # -------------------------------------------------------------------------
+  - it: agent-manager service exposes management port 8094
+    set:
+      agentManager.enabled: true
+      secrets.agentDiscordBotToken: ci-token
+      secrets.agentDiscordChannelId: "123456"
+      secrets.agentAnthropicApiKey: ci-key
+    templates:
+      - templates/agent-manager.yaml
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            port: 8094
+            targetPort: management
+            protocol: TCP
+            name: management
+        documentIndex: 1

--- a/helm/omcsi/values.yaml
+++ b/helm/omcsi/values.yaml
@@ -338,6 +338,10 @@ monitoring:
     #   labels:
     #     grafana_dashboard: "1"
     labels: {}
+  # Namespace where Prometheus is deployed. Used by NetworkPolicies to allow
+  # cross-namespace scrape traffic when monitoring.enabled is true.
+  # Override if you deploy kube-prometheus-stack in a non-default namespace.
+  prometheusNamespace: monitoring
 
 # ---------------------------------------------------------------------------
 # Persistence

--- a/helm/omcsi/values.yaml
+++ b/helm/omcsi/values.yaml
@@ -313,6 +313,33 @@ podDisruptionBudgets:
   enabled: true
 
 # ---------------------------------------------------------------------------
+# Monitoring
+# ---------------------------------------------------------------------------
+# When enabled, a ServiceMonitor is created for each service that exposes
+# Spring Boot Actuator Prometheus metrics (/actuator/prometheus).
+# Requires the Prometheus Operator (kube-prometheus-stack or standalone) to
+# be installed in the cluster.
+monitoring:
+  enabled: false
+  serviceMonitor:
+    # Extra labels added to every ServiceMonitor. Use this to match your
+    # Prometheus Operator's serviceMonitorSelector, e.g.:
+    #   labels:
+    #     release: kube-prometheus-stack
+    labels: {}
+    interval: "30s"
+    scrapeTimeout: "10s"
+  grafanaDashboard:
+    # When true, a ConfigMap containing a sample Grafana dashboard JSON is
+    # created. Import it in Grafana or let the Grafana sidecar pick it up.
+    enabled: true
+    # Extra labels added to the dashboard ConfigMap. Use this to target the
+    # Grafana sidecar, e.g.:
+    #   labels:
+    #     grafana_dashboard: "1"
+    labels: {}
+
+# ---------------------------------------------------------------------------
 # Persistence
 # ---------------------------------------------------------------------------
 persistence:

--- a/minecraft-wrapper/build.gradle
+++ b/minecraft-wrapper/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'io.swagger.core.v3:swagger-annotations:2.2.19'
     compileOnly 'org.projectlombok:lombok'

--- a/minecraft-wrapper/src/main/resources/application.properties
+++ b/minecraft-wrapper/src/main/resources/application.properties
@@ -32,5 +32,9 @@ spring.servlet.multipart.max-request-size=100MB
 logs.diagnostic.enabled=${LOGS_DIAGNOSTIC_ENABLED:false}
 logs.diagnostic.max-lines=${LOGS_DIAGNOSTIC_MAX_LINES:100}
 
+# Actuator configuration
+management.endpoints.web.exposure.include=health,prometheus
+management.endpoint.health.show-details=always
+
 # Logging
 logging.level.com.openmc.minecraftwrapper=INFO

--- a/terraform/aws/traefik.tf
+++ b/terraform/aws/traefik.tf
@@ -5,9 +5,11 @@
 module "traefik" {
   source = "../modules/traefik"
 
-  enable_traefik    = var.enable_traefik
-  helm_namespace    = var.helm_namespace
-  helm_release_name = var.helm_release_name
+  enable_traefik          = var.enable_traefik
+  helm_namespace          = var.helm_namespace
+  helm_release_name       = var.helm_release_name
+  enable_grafana_route    = var.enable_grafana_route
+  grafana_service_address = var.grafana_service_address
 
   depends_on = [module.omcsi]
 }

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -123,6 +123,18 @@ variable "enable_traefik" {
   default     = false
 }
 
+variable "enable_grafana_route" {
+  description = "Expose a Traefik TCP entrypoint on port 3000 that forwards to Grafana. Only enable when Grafana is installed (e.g. via kube-prometheus-stack). Requires enable_traefik = true."
+  type        = bool
+  default     = false
+}
+
+variable "grafana_service_address" {
+  description = "Cluster-internal DNS address (host:port) of the Grafana Service used by the Traefik route. Only relevant when enable_grafana_route = true."
+  type        = string
+  default     = "kube-prometheus-stack-grafana.monitoring.svc.cluster.local:80"
+}
+
 variable "helm_values_file" {
   description = "Optional path to a custom Helm values file to merge. Leave empty to use defaults."
   type        = string

--- a/terraform/existing-cluster/traefik.tf
+++ b/terraform/existing-cluster/traefik.tf
@@ -5,9 +5,11 @@
 module "traefik" {
   source = "../modules/traefik"
 
-  enable_traefik    = var.enable_traefik
-  helm_namespace    = var.helm_namespace
-  helm_release_name = var.helm_release_name
+  enable_traefik          = var.enable_traefik
+  helm_namespace          = var.helm_namespace
+  helm_release_name       = var.helm_release_name
+  enable_grafana_route    = var.enable_grafana_route
+  grafana_service_address = var.grafana_service_address
 
   depends_on = [module.omcsi]
 }

--- a/terraform/existing-cluster/variables.tf
+++ b/terraform/existing-cluster/variables.tf
@@ -87,6 +87,18 @@ variable "enable_traefik" {
   default     = false
 }
 
+variable "enable_grafana_route" {
+  description = "Expose a Traefik TCP entrypoint on port 3000 that forwards to Grafana. Only enable when Grafana is installed (e.g. via kube-prometheus-stack). Requires enable_traefik = true."
+  type        = bool
+  default     = false
+}
+
+variable "grafana_service_address" {
+  description = "Cluster-internal DNS address (host:port) of the Grafana Service used by the Traefik route. Only relevant when enable_grafana_route = true."
+  type        = string
+  default     = "kube-prometheus-stack-grafana.monitoring.svc.cluster.local:80"
+}
+
 variable "helm_values_file" {
   description = "Optional path to a custom Helm values file to merge. Leave empty to use defaults."
   type        = string

--- a/terraform/linode/traefik.tf
+++ b/terraform/linode/traefik.tf
@@ -5,9 +5,11 @@
 module "traefik" {
   source = "../modules/traefik"
 
-  enable_traefik    = var.enable_traefik
-  helm_namespace    = var.helm_namespace
-  helm_release_name = var.helm_release_name
+  enable_traefik          = var.enable_traefik
+  helm_namespace          = var.helm_namespace
+  helm_release_name       = var.helm_release_name
+  enable_grafana_route    = var.enable_grafana_route
+  grafana_service_address = var.grafana_service_address
 
   depends_on = [module.omcsi]
 }

--- a/terraform/linode/variables.tf
+++ b/terraform/linode/variables.tf
@@ -125,6 +125,18 @@ variable "enable_traefik" {
   default     = false
 }
 
+variable "enable_grafana_route" {
+  description = "Expose a Traefik TCP entrypoint on port 3000 that forwards to Grafana. Only enable when Grafana is installed (e.g. via kube-prometheus-stack). Requires enable_traefik = true."
+  type        = bool
+  default     = false
+}
+
+variable "grafana_service_address" {
+  description = "Cluster-internal DNS address (host:port) of the Grafana Service used by the Traefik route. Only relevant when enable_grafana_route = true."
+  type        = string
+  default     = "kube-prometheus-stack-grafana.monitoring.svc.cluster.local:80"
+}
+
 variable "helm_values_file" {
   description = "Optional path to a custom Helm values file to merge. Leave empty to use defaults."
   type        = string

--- a/terraform/modules/traefik/main.tf
+++ b/terraform/modules/traefik/main.tf
@@ -47,6 +47,10 @@ resource "kubernetes_config_map" "traefik_dynamic_config" {
             entryPoints: ["web"]
             rule: "HostSNI(`*`)"
             service: nginx-http-svc
+          grafana:
+            entryPoints: ["grafana"]
+            rule: "HostSNI(`*`)"
+            service: grafana-svc
         services:
           minecraft-svc:
             loadBalancer:
@@ -60,6 +64,10 @@ resource "kubernetes_config_map" "traefik_dynamic_config" {
             loadBalancer:
               servers:
                 - address: "${var.helm_release_name}-nginx.${var.helm_namespace}.svc.cluster.local:80"
+          grafana-svc:
+            loadBalancer:
+              servers:
+                - address: "kube-prometheus-stack-grafana.monitoring.svc.cluster.local:80"
     EOT
   }
 }
@@ -93,6 +101,12 @@ resource "helm_release" "traefik" {
         expose:
           default: true
         exposedPort: 25565
+        protocol: TCP
+      grafana:
+        port: 3000
+        expose:
+          default: true
+        exposedPort: 3000
         protocol: TCP
     service:
       type: LoadBalancer

--- a/terraform/modules/traefik/main.tf
+++ b/terraform/modules/traefik/main.tf
@@ -47,10 +47,10 @@ resource "kubernetes_config_map" "traefik_dynamic_config" {
             entryPoints: ["web"]
             rule: "HostSNI(`*`)"
             service: nginx-http-svc
-          grafana:
+          %{if var.enable_grafana_route}grafana:
             entryPoints: ["grafana"]
             rule: "HostSNI(`*`)"
-            service: grafana-svc
+            service: grafana-svc%{endif}
         services:
           minecraft-svc:
             loadBalancer:
@@ -64,10 +64,10 @@ resource "kubernetes_config_map" "traefik_dynamic_config" {
             loadBalancer:
               servers:
                 - address: "${var.helm_release_name}-nginx.${var.helm_namespace}.svc.cluster.local:80"
-          grafana-svc:
+          %{if var.enable_grafana_route}grafana-svc:
             loadBalancer:
               servers:
-                - address: "kube-prometheus-stack-grafana.monitoring.svc.cluster.local:80"
+                - address: "${var.grafana_service_address}"%{endif}
     EOT
   }
 }
@@ -102,12 +102,12 @@ resource "helm_release" "traefik" {
           default: true
         exposedPort: 25565
         protocol: TCP
-      grafana:
+      %{if var.enable_grafana_route}grafana:
         port: 3000
         expose:
           default: true
         exposedPort: 3000
-        protocol: TCP
+        protocol: TCP%{endif}
     service:
       type: LoadBalancer
     additionalArguments:

--- a/terraform/modules/traefik/variables.tf
+++ b/terraform/modules/traefik/variables.tf
@@ -15,3 +15,15 @@ variable "helm_release_name" {
   type        = string
   default     = "omcsi"
 }
+
+variable "enable_grafana_route" {
+  description = "Expose a Traefik TCP entrypoint on port 3000 forwarding to Grafana. Only enable when Grafana is installed in the cluster (e.g. via kube-prometheus-stack)."
+  type        = bool
+  default     = false
+}
+
+variable "grafana_service_address" {
+  description = "Cluster-internal DNS address (host:port) of the Grafana Service. Only used when enable_grafana_route is true."
+  type        = string
+  default     = "kube-prometheus-stack-grafana.monitoring.svc.cluster.local:80"
+}

--- a/web-app/build.gradle
+++ b/web-app/build.gradle
@@ -25,6 +25,8 @@ configurations {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'io.swagger.core.v3:swagger-annotations:2.2.19'

--- a/web-app/src/main/resources/application.properties
+++ b/web-app/src/main/resources/application.properties
@@ -54,7 +54,7 @@ deployment.auth.token=${DEPLOYMENT_AUTH_TOKEN:}
 
 # Actuator configuration
 management.endpoints.web.exposure.include=health,prometheus
-management.endpoint.health.show-details=always
+management.endpoint.health.show-details=when_authorized
 
 # Logging
 logging.level.com.openmc.webapp=INFO

--- a/web-app/src/main/resources/application.properties
+++ b/web-app/src/main/resources/application.properties
@@ -52,5 +52,9 @@ data.storage.base-directory=${DATA_STORAGE_PATH:/app/data}
 # Deployment History
 deployment.auth.token=${DEPLOYMENT_AUTH_TOKEN:}
 
+# Actuator configuration
+management.endpoints.web.exposure.include=health,prometheus
+management.endpoint.health.show-details=always
+
 # Logging
 logging.level.com.openmc.webapp=INFO


### PR DESCRIPTION
## Summary

- Adds `monitoring.enabled` gate (default `false`) in `values.yaml`
- When enabled, creates one `ServiceMonitor` per Spring Boot service targeting `/actuator/prometheus`:
  - `minecraft-wrapper` — internal service, `wrapper` port 8092
  - `webapp` — `http` port 8080
  - `alert-manager` — `http` port 8090
  - `backup-manager` — `http` port 8091
  - `agent-manager` — `management` port 8094 (only when `agentManager.enabled: true`)
- Each scraped `Service` gains an `omcsi.io/metrics: "true"` label so `ServiceMonitor` selectors skip the external minecraft-wrapper NodePort
- Agent-manager's management port 8094 is now exposed in its `Service` spec
- Adds a Grafana dashboard `ConfigMap` (`monitoring.grafanaDashboard.enabled`, default `true` when monitoring is on) with panels for service uptime, JVM heap, HTTP request rate/latency, CPU usage, and GC pause time
- `monitoring.serviceMonitor.labels` and `monitoring.grafanaDashboard.labels` allow matching Prometheus Operator's `serviceMonitorSelector` and Grafana's sidecar label, e.g. `release: kube-prometheus-stack` / `grafana_dashboard: "1"`
- Adds `micrometer-registry-prometheus` dependency to all five Spring Boot services so `/actuator/prometheus` is available
- Adds cross-namespace NetworkPolicy ingress rules on all scraped services allowing Prometheus (in `monitoring` namespace) to reach metrics ports; gated by `monitoring.enabled`
- Dashboard JSON uses literal datasource UID (`prometheus`) rather than the `${DS_PROMETHEUS}` import placeholder, so Grafana sidecar provisioning resolves the datasource correctly
- Dashboard legends use `{{job}}` (service name) instead of `{{instance}}` (pod IP) for readability
- Marks `KUBERNETES_IMPROVEMENTS.md` item 11 as resolved

Closes #152

## Test plan

- [x] `helm unittest helm/omcsi` — 107 tests pass (18 new monitoring tests)
- [x] Deployed with `monitoring.enabled: true` and `kube-prometheus-stack` — all four Spring Boot targets confirmed `up` in Prometheus
- [x] Grafana dashboard provisioned via sidecar ConfigMap — panels render with live data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_