### PR TITLE
Add cheapest cloud target: self-managed kubeadm on Hetzner (~$14/mo)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,6 +368,24 @@ jobs:
         terraform -chdir=terraform/existing-cluster validate
         echo "✓ Existing Cluster Terraform configuration is valid"
 
+    - name: Terraform fmt check (Hetzner)
+      run: |
+        echo "🔍 Checking Terraform formatting (Hetzner)..."
+        terraform -chdir=terraform/hetzner fmt -check -diff
+        echo "✓ Hetzner Terraform files are properly formatted"
+
+    - name: Terraform init (Hetzner)
+      run: |
+        echo "⚙️ Initializing Terraform (Hetzner)..."
+        terraform -chdir=terraform/hetzner init -backend=false
+        echo "✓ Hetzner Terraform initialized"
+
+    - name: Terraform validate (Hetzner)
+      run: |
+        echo "✅ Validating Terraform configuration (Hetzner)..."
+        terraform -chdir=terraform/hetzner validate
+        echo "✓ Hetzner Terraform configuration is valid"
+
   security-scan:
     name: Security Scanning
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -55,6 +55,11 @@ jobs:
           # Version is validated above; simple assignment is safe here
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
+      # QEMU enables cross-building the arm64 image on the amd64 runner so the
+      # published manifest serves ARM hosts (e.g. Hetzner CAX, Oracle Ampere).
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -70,6 +75,8 @@ jobs:
         with:
           context: .
           file: Dockerfile
+          # Multi-arch manifest so the image runs on both x86 and ARM hosts.
+          platforms: linux/amd64,linux/arm64
           build-args: MINECRAFT_VERSION=${{ steps.mc_version.outputs.version }}
           push: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.push_images == 'true' }}
           tags: |
@@ -77,8 +84,10 @@ jobs:
             dmccoystephenson/open-mc-server:${{ steps.mc_version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          # BuildTools downloads Spigot source and compiles it — this takes ~20 minutes.
-          # The GHA cache significantly reduces rebuild time on subsequent runs.
+          # BuildTools downloads Spigot source and compiles it — this takes ~20 minutes
+          # on amd64. The arm64 leg builds under QEMU emulation and is significantly
+          # slower; for faster builds, run this job on a native arm64 runner and drop
+          # QEMU. The GHA cache significantly reduces rebuild time on subsequent runs.
 
   build-supporting-images:
     name: Build supporting images
@@ -106,6 +115,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # QEMU enables cross-building the arm64 images on the amd64 runner so the
+      # published manifests serve ARM hosts (e.g. Hetzner CAX, Oracle Ampere).
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -121,6 +135,8 @@ jobs:
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
+          # Multi-arch manifest so the image runs on both x86 and ARM hosts.
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.push_images == 'true' }}
           tags: dmccoystephenson/${{ matrix.name }}:latest
           cache-from: type=gha

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ terraform/**/*.tfstate
 terraform/**/*.tfstate.backup
 terraform/**/terraform.tfvars
 terraform/linode/kubeconfig.yaml
+terraform/hetzner/kubeconfig.yaml

--- a/CI-DOCUMENTATION.md
+++ b/CI-DOCUMENTATION.md
@@ -10,57 +10,85 @@ The CI pipeline runs automatically on:
 
 ## CI Jobs
 
-### 1. Validate Code and Configuration
+The pipeline (`.github/workflows/ci.yml`) is composed of several parallel jobs.
+The end-to-end server run lives in a separate workflow
+(`.github/workflows/test-server-run.yml`).
 
-This is the main validation job that performs comprehensive checks across multiple areas:
+### 1. Validate Code and Configuration (`validate`)
+
+The main per-PR validation job. It runs the following steps in order:
 
 #### Shell Script Validation
-- **Syntax Checking**: Validates that all shell scripts have correct bash syntax using `bash -n`
-  - Checks: `up.sh`, `down.sh`, `resources/post-create.sh`, `resources/minecraft-wrapper.sh`
-- **ShellCheck Linting**: Runs static analysis on all shell scripts to catch common issues
-  - Validates code quality, potential bugs, and best practices
-  - Checks all `.sh` files in `resources/` and `scripts/` directories
+- **Syntax Checking** (`bash -n`): `up.sh`, `down.sh`, `upgrade.sh`,
+  `trigger-backup.sh`, `resources/post-create.sh`.
+- **ShellCheck Linting**: the same five scripts plus everything under
+  `scripts/*.sh`.
 
 #### Docker Configuration Validation
-- **Dockerfile Validation**: 
-  - Verifies Dockerfile exists and contains required `FROM` directive
-  - Tests Docker build process up to the `base` stage
-- **Docker Compose Validation**:
-  - Creates test environment file with valid placeholder values
-  - Validates compose configuration syntax using `docker compose config`
-  - Ensures all required services and volumes are properly defined
+- **Dockerfile Validation**: verifies the root `Dockerfile` exists and contains
+  a `FROM` directive, then builds the `base` stage to confirm syntax.
+- **Docker Compose Validation**: writes a temporary `.env` with placeholder
+  values, then runs `docker compose config` to verify the compose file parses
+  and every service/volume reference resolves.
 
 #### Environment Configuration Validation
-- **Sample Environment File**: Validates `sample.env` contains all required variables:
-  - `MINECRAFT_VERSION`
-  - `OPERATOR_UUID`
-  - `OPERATOR_NAME`
-  - `SERVER_MOTD`
+Asserts `sample.env` declares each of these keys (`grep -q KEY=`):
+`MINECRAFT_VERSION`, `OPERATOR_UUID`, `OPERATOR_NAME`, `SERVER_MOTD`.
+
+#### Java Module Builds and Tests
+Sets up JDK 21 (Temurin), then runs `./gradlew build` and `./gradlew test`
+for each Spring Boot module that has its own Gradle project:
+- `web-app`
+- `minecraft-wrapper`
+- `agent-manager`
+
+(Other modules — `alert-manager`, `backup-manager` — are exercised indirectly
+via the Helm tests and the end-to-end server run.)
 
 #### Documentation Validation
-- **README.md**: Verifies main documentation exists and has correct structure
-- **LICENSE**: Ensures license file is present
+- Confirms `README.md` exists and contains the expected H1
+  (`# Open Minecraft Server Infrastructure`).
+- Confirms `LICENSE` is present.
 
-#### Graceful Shutdown Testing
-- **Functionality Test**: Executes comprehensive test of the graceful shutdown mechanism
-  - Tests SIGTERM signal handling
-  - Verifies proper stop command transmission via FIFO
-  - Validates plugin data preservation during shutdown
-  - Confirms clean server termination
+#### Helm Chart Linting
+- Sets up Helm and runs `helm lint helm/omcsi` against the chart.
 
-### 2. Security Scanning
+### 2. Helm Unit Tests (`helm-unit-test`)
+
+A separate job that installs the
+[`helm-unittest`](https://github.com/helm-unittest/helm-unittest) plugin and
+runs `helm unittest helm/omcsi`. The test suites live under
+`helm/omcsi/tests/` and cover NetworkPolicies, PodDisruptionBudgets,
+ServiceMonitors, security contexts, and per-service Deployment/Service
+templates.
+
+### 3. Helm Deploy Smoke Test (`helm-deploy-test`)
+
+Spins up a `kind` cluster, installs the chart with minimal required values,
+and checks the resulting workloads come up healthy. Catches template
+regressions that lint and unit tests miss (e.g. selector mismatches,
+PVC binding failures).
+
+### 4. Terraform Validate (`terraform-validate`)
+
+Runs `terraform init -backend=false` and `terraform validate` for each
+Terraform stack under `terraform/` (`aws`, `linode`, `existing-cluster`,
+and the shared modules) to catch syntax and provider errors before
+they hit a real deployment.
+
+### 5. Security Scanning (`security-scan`)
 
 Performs security vulnerability scanning using Trivy:
 
-#### Trivy File System Scan
 - **Vulnerability Detection**: Scans entire repository for known security vulnerabilities
 - **SARIF Report Generation**: Creates standardized security report format
 - **GitHub Security Integration**: Uploads results to GitHub Security tab for review
 - **Non-blocking**: Continues pipeline execution even if vulnerabilities are found (informational)
 
-### 3. Test Server Run
+### 6. End-to-End Server Run (`test-server-run.yml`)
 
-Performs end-to-end testing by actually running the Minecraft server in a containerized environment:
+A separate workflow that performs end-to-end testing by actually running
+the Minecraft server in a containerized environment.
 
 #### Server Build and Startup
 - **Docker Image Build**: Builds the complete Minecraft server Docker image with Spigot
@@ -77,7 +105,8 @@ Performs end-to-end testing by actually running the Minecraft server in a contai
 - **Log Validation**: Confirms graceful shutdown signals are processed correctly
 - **Resource Cleanup**: Ensures all resources are properly cleaned up after testing
 
-This test provides real-world verification that the server can actually start, run, and stop correctly in a production-like environment.
+This workflow provides real-world verification that the server can actually
+start, run, and stop correctly in a production-like environment.
 
 ## Local Testing
 
@@ -92,30 +121,35 @@ This script mirrors the CI pipeline checks and helps catch issues before submitt
 ## What Gets Checked
 
 ### ✅ Code Quality
-- Shell script syntax correctness
+- Shell script syntax (`bash -n`)
 - ShellCheck linting compliance
-- File permission validation
+- Java module compilation and unit tests for `web-app`,
+  `minecraft-wrapper`, and `agent-manager`
 
 ### ✅ Configuration Integrity
-- Docker build process validation
-- Docker Compose configuration syntax
-- Environment variable completeness
+- Dockerfile parses and the `base` stage builds
+- `docker compose config` resolves the full stack
+- `sample.env` declares all required keys
+- Terraform stacks pass `terraform validate`
 
-### ✅ Functionality Verification
-- Graceful shutdown mechanism testing
-- Server wrapper script reliability
-- Plugin data preservation
-- Full server run testing with actual Minecraft server
-- Port availability and network functionality
-- Server file system initialization
+### ✅ Kubernetes / Helm
+- `helm lint` against `helm/omcsi`
+- `helm unittest` covering NetworkPolicies, PDBs, ServiceMonitors,
+  security contexts, and per-service templates
+- Smoke deploy of the chart into a `kind` cluster
+
+### ✅ End-to-End (separate workflow)
+- Real Spigot build + server boot
+- Port availability (25565, 25575) and file-system initialization
+- Graceful shutdown via Compose
 
 ### ✅ Security Assessment
-- Vulnerability scanning
-- Security best practices
+- Trivy vulnerability scanning
+- Results uploaded to the GitHub Security tab
 
 ### ✅ Documentation Standards
-- Required documentation presence
-- Structure validation
+- `README.md` exists with the expected H1
+- `LICENSE` is present
 
 ## CI/CD Plugin Deployment
 
@@ -198,10 +232,21 @@ The workflow:
 - Verify all required files are present
 - Test `docker build` locally
 
-### Graceful Shutdown Test Failures
-- Check that the wrapper script handles signals correctly
-- Verify FIFO communication works properly
-- Test shutdown sequence manually
+### Java Module Build / Test Failures
+- Run `./gradlew build` and `./gradlew test` locally inside the affected
+  module (`web-app`, `minecraft-wrapper`, or `agent-manager`) to reproduce.
+- Confirm you're on JDK 21 — older or newer JDKs may produce class-version
+  errors that look unrelated.
+
+### Helm Lint / Unit Test Failures
+- `helm lint helm/omcsi` reproduces lint output locally.
+- `helm unittest helm/omcsi` reproduces template assertions; look at
+  `helm/omcsi/tests/*.yaml` for which template a failing assertion belongs to.
+
+### Helm Deploy Smoke Test Failures
+- Usually a selector mismatch, missing required value, or PVC binding
+  failure on the kind cluster. Render with `helm template omcsi helm/omcsi
+  --values <your-overrides>.yaml` to see what would be applied.
 
 ### Environment Configuration Failures
 - Ensure all required variables are defined in `sample.env`
@@ -213,6 +258,13 @@ The workflow:
 - Ensure sufficient resources are available for server build
 - Check for port conflicts or networking issues
 - Review server configuration in test environment
+
+### Graceful Shutdown Test Failures (end-to-end workflow)
+- Check that `minecraft-wrapper` handles signals correctly
+- Verify FIFO communication works properly between the wrapper and the
+  Spigot process
+- Test the shutdown sequence manually with
+  `scripts/test-docker-graceful-shutdown.sh`
 
 ## Performance
 

--- a/CI-DOCUMENTATION.md
+++ b/CI-DOCUMENTATION.md
@@ -71,10 +71,11 @@ PVC binding failures).
 
 ### 4. Terraform Validate (`terraform-validate`)
 
-Runs `terraform init -backend=false` and `terraform validate` for each
-Terraform stack under `terraform/` (`aws`, `linode`, `existing-cluster`,
-and the shared modules) to catch syntax and provider errors before
-they hit a real deployment.
+Runs `terraform fmt -check`, `terraform init -backend=false`, and
+`terraform validate` for each Terraform stack under `terraform/`
+(`aws`, `linode`, `existing-cluster`, and `hetzner`) to catch
+formatting issues, syntax errors, and provider errors before they
+hit a real deployment.
 
 ### 5. Security Scanning (`security-scan`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ Checklist for any PR touching services, config, or infrastructure:
 | `sample.env` | Template for all environment variables (Docker) |
 | `up.sh` / `down.sh` | Docker Compose lifecycle scripts |
 | `helm/omcsi/` | Helm chart for Kubernetes deployment |
+| `terraform/hetzner/` | Terraform config that provisions one Hetzner server, self-manages a single-node kubeadm cluster on it (cloud-init), and deploys the Helm chart — the cheapest cloud target (~$14/mo). Deploys via SSH from the node (not the Helm provider) since a kubeadm node has no API credentials as resource attributes at plan time. |
 | `terraform/linode/` | Terraform config that provisions LKE and deploys the Helm chart |
 | `<service>/` | One directory per service (source code, Dockerfile) |
 | `scripts/ci-local.sh` | Local CI validation script |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Checklist for any PR touching services, config, or infrastructure:
 | `nginx` | 80 / 443 | Reverse proxy |
 | `alert-manager` | 8090 | Discord webhook notifications |
 | `backup-manager` | 8091 | Scheduled backups |
-| `agent-manager` | 8093 / 8094 | Discord AI bot (disabled by default) |
+| `agent-manager` | 8093 (API), 8094 (Spring management/actuator, container-internal) | Discord AI bot (disabled by default) |
 
 ## Verification Before Marking Work Done
 

--- a/README.md
+++ b/README.md
@@ -677,9 +677,10 @@ These settings allow you to run multiple server instances in parallel without co
 - `HOST_PORT`: Host port for Minecraft server (default: `25565`)
 - `HOST_RCON_PORT`: Host port for RCON (default: `25575`)
 - `HOST_BLUEMAP_PORT`: Host port for BlueMap (default: `8100`)
+- `WRAPPER_PORT`: Host port for the minecraft-wrapper REST API (default: `8092`)
 - `VOLUME_NAME`: Docker volume name for persistent data (default: `mcserver`)
 
-To run multiple servers simultaneously (e.g., for testing different configurations), create separate `.env` files with unique values for `CONTAINER_NAME`, `HOST_PORT`, `HOST_RCON_PORT`, `HOST_BLUEMAP_PORT`, `VOLUME_NAME`, `WEB_CONTAINER_NAME`, `NGINX_CONTAINER_NAME`, `BACKUP_CONTAINER_NAME`, `ALERT_CONTAINER_NAME`, `ALERT_PORT`, `WEB_HTTP_PORT`, and `WEB_HTTPS_PORT`, then start each with:
+To run multiple servers simultaneously (e.g., for testing different configurations), create separate `.env` files with unique values for `CONTAINER_NAME`, `HOST_PORT`, `HOST_RCON_PORT`, `HOST_BLUEMAP_PORT`, `WRAPPER_PORT`, `VOLUME_NAME`, `WEB_CONTAINER_NAME`, `NGINX_CONTAINER_NAME`, `BACKUP_CONTAINER_NAME`, `ALERT_CONTAINER_NAME`, `BACKUP_PORT`, `ALERT_PORT`, `AGENT_PORT`, `WEB_HTTP_PORT`, and `WEB_HTTPS_PORT`, then start each with:
 
 ```bash
 docker compose --env-file .env.dev2 up -d --build
@@ -740,7 +741,7 @@ See [alert-manager/README.md](alert-manager/README.md) for detailed configuratio
 ### Agent Manager Configuration
 
 - `AGENT_CONTAINER_NAME`: Agent manager container name (default: `open-mc-agent-manager`)
-- `AGENT_PORT`: Agent manager API port (default: `8093`)
+- `AGENT_PORT`: Agent manager API port (default: `8093`). The Spring Boot management/actuator endpoint also listens on `8094` inside the container but is not published to the host by default — see `agent-manager/README.md` for details.
 - `AGENT_DISCORD_BOT_TOKEN`: Discord bot token (required for agent manager)
 - `AGENT_DISCORD_CHANNEL_ID`: Discord channel ID to listen on (required for agent manager)
 - `AGENT_ANTHROPIC_API_KEY`: Anthropic API key (required for agent manager)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ The Self-Hosting Guide covers:
 - Monitoring and maintenance
 - Advanced security configurations
 
+### Cheapest Cloud Hosting (Hetzner, ~$14/month)
+If you want to run OMCSI in the cloud for the lowest possible cost, the **[Hetzner single-node Terraform module](#deploying-to-hetzner-cloud-cheapest-single-node)** provisions one server, self-manages a `kubeadm` Kubernetes cluster on it, and deploys the Helm chart — all under the $20/month target with no managed-control-plane fee, cloud LoadBalancer, or NAT gateway. See the [Cost Analysis](terraform/COST_ANALYSIS.md) for how this compares to managed Kubernetes (LKE ~$109/mo, EKS ~$248/mo).
+
 ### Kubernetes (Helm)
 OMCSI ships with a Helm chart in [`helm/omcsi/`](helm/omcsi/) for deploying to any Kubernetes cluster (k3s, kind, EKS, GKE, etc.).
 
@@ -341,6 +344,76 @@ minikube delete
 | PVC stuck in `Pending` | No default storage class | Minikube ships with a default `StorageClass`; verify with `kubectl get sc` |
 | Cannot reach services | Minikube tunnel not running | Run `minikube tunnel` for `LoadBalancer` services, or use `minikube service <name> -n omcsi` for `NodePort` |
 | Pods `CrashLoopBackOff` | Application startup failure | Check logs with `kubectl logs -n omcsi <pod-name>` |
+
+#### Deploying to Hetzner Cloud (cheapest, single node)
+
+The [`terraform/hetzner/`](terraform/hetzner/) directory contains Terraform configuration that provisions a **single Hetzner Cloud server**, bootstraps a self-managed single-node Kubernetes cluster on it with `kubeadm`, and deploys the OMCSI Helm chart — in one `terraform apply`. It is the **lowest-cost cloud option (~$14/month on the default `cax31`)** because it carries none of the managed-Kubernetes charges:
+
+- **No control-plane fee** — the control plane runs on the same node (untainted so workloads schedule on it)
+- **No cloud LoadBalancer** — services are exposed via fixed NodePorts (25565/80/443) on the node's public IP (the API server's `--service-node-port-range` is widened to `80-32767`)
+- **No NAT gateway** — the node has a public IP directly
+- **No separate block storage** — the [Rancher local-path provisioner](https://github.com/rancher/local-path-provisioner) backs PVCs with the node's included NVMe
+
+The cluster uses **containerd**, **Calico** (so the chart's NetworkPolicies are enforced), and Helm. See [Cost Analysis](terraform/COST_ANALYSIS.md) for the full comparison.
+
+> **Trade-off:** You self-manage the cluster (upgrades, etcd backups, node maintenance) and there is no HA — this is the explicit deal for the lower price. The setup maps directly onto CKA-style skills (kubeadm, CNI, taints, NodePort ranges, StorageClasses).
+
+**Prerequisites**
+- [Terraform](https://developer.hashicorp.com/terraform/install) >= 1.3
+- A [Hetzner Cloud API token](https://docs.hetzner.com/cloud/api/getting-started/generating-api-token/) (Read & Write)
+- An SSH key pair (Terraform bootstraps and deploys over SSH)
+
+**Quick Start**
+
+```bash
+cd terraform/hetzner
+
+# Copy the example tfvars and fill in your values
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars – set hcloud_token, ssh_public_key, ssh_private_key_path,
+# rcon_password, and admin_password at minimum
+
+terraform init
+terraform plan
+terraform apply
+```
+
+`terraform apply` prints the connection details when it finishes:
+
+```bash
+terraform output minecraft_address   # e.g. 203.0.113.10:25565 – connect your client here
+terraform output dashboard_url       # https://203.0.113.10 – self-signed cert (expect a warning)
+terraform output kubectl_hint        # export KUBECONFIG=... && kubectl get pods -n omcsi
+```
+
+> **First-boot time:** The server spends several minutes on first boot bootstrapping Kubernetes (cloud-init) before Helm deploys. Terraform waits for this automatically. Watch progress with `ssh -i <key> root@<ip> 'tail -f /var/log/omcsi-bootstrap.log'`.
+
+**Key Variables**
+
+| Variable | Description | Default |
+|---|---|---|
+| `hcloud_token` | Hetzner Cloud API token | *(required)* |
+| `ssh_public_key` | SSH public key contents added to the server | *(required)* |
+| `ssh_private_key_path` | Path to the matching private key (used for provisioning) | *(required)* |
+| `rcon_password` / `admin_password` | OMCSI secrets | *(required)* |
+| `server_type` | Hetzner server type | `cax31` (ARM, 16 GB) |
+| `location` | Hetzner location (CAX/ARM is EU-only: `fsn1`/`nbg1`/`hel1`) | `fsn1` |
+| `allowed_ssh_cidr` | CIDR allowed to reach SSH (22) and the K8s API (6443) | `0.0.0.0/0` *(restrict this)* |
+| `kubernetes_version` | Kubernetes minor version | `1.34` |
+| `java_opts` | Minecraft JVM heap (sized for 16 GB) | `-Xmx6G -Xms4G` |
+| `image_registry` | Container image registry prefix | `dmccoystephenson` |
+
+See [`terraform/hetzner/variables.tf`](terraform/hetzner/variables.tf) for the full list (operator identity, MOTD, Discord, agent-manager, NodePort overrides, etc.).
+
+> **ARM images:** `cax31` is ARM64. The default `dmccoystephenson` images are published multi-arch (amd64 + arm64), so they run as-is. For an x86 server, set `server_type = "cpx31"` and `location` to any region.
+
+**Tear Down**
+
+```bash
+terraform destroy
+```
+
+This removes the server, firewall, and SSH key. **All world data on the node is destroyed** — back up first (the backup-manager writes to a PVC on the node; copy it off before destroying).
 
 #### Deploying to Linode with Terraform
 

--- a/UPGRADE-GUIDE.md
+++ b/UPGRADE-GUIDE.md
@@ -26,6 +26,13 @@ This guide provides a comprehensive process for upgrading your Minecraft server 
 - Access to the server host machine
 - Sufficient disk space for backups (at least 2x your current world size)
 - Knowledge of the target Minecraft version you want to upgrade to
+- A working JDK if you intend to rebuild any Spring Boot modules locally
+  (`web-app`, `minecraft-wrapper`, `agent-manager`, etc.) outside of Docker.
+  The service containers ship with **JDK 21** (`eclipse-temurin:21-jre`); the
+  main Minecraft server image builds Spigot with **JDK 25**
+  (`eclipse-temurin:25.0.3_9-jdk-noble`). If you only edit the `.env` file
+  and rebuild via `./upgrade.sh` or `docker compose build`, no host JDK is
+  required — Docker handles everything.
 
 ## Upgrade Process
 

--- a/agent-manager/README.md
+++ b/agent-manager/README.md
@@ -298,7 +298,18 @@ At DEBUG level, the agent-manager logs additional detail at each step:
 - Only the user who requested an action can confirm it via reaction
 - Pending confirmations expire after 5 minutes to prevent stale actions
 - The Discord bot only listens in the configured channel
-- The Actuator management endpoints (`/loggers`, `/health`) run on a separate port (8094). In Docker Compose this port is not mapped to the host, so it is only reachable from within the Docker network. In Kubernetes it is not exposed via any Service or Ingress, but it remains reachable on the cluster network via the pod IP (including by the kubelet for health probes). Use NetworkPolicies to restrict access if required
+- The Actuator management endpoints (`/loggers`, `/health`) run on a separate
+  port (8094). In Docker Compose this port is not published to the host, so it
+  is only reachable from within the Docker network. In Kubernetes the chart
+  *does* expose 8094 as a Service port named `management`
+  (`helm/omcsi/templates/agent-manager.yaml`) — the kubelet uses it for health
+  probes and Prometheus uses it for metric scraping. It is **not** exposed via
+  any Ingress, and the bundled NetworkPolicy restricts ingress to 8094 to the
+  kubelet (via the node CIDR) and to the Prometheus pod in the monitoring
+  namespace. If you disable NetworkPolicies, use a CNI that does not enforce
+  them, or modify the bundled policies, harden access yourself before treating
+  the actuator as private — by default Service IPs are reachable from every
+  pod on the cluster.
 
 ## Troubleshooting
 

--- a/alert-manager/README.md
+++ b/alert-manager/README.md
@@ -20,7 +20,7 @@ The following environment variables can be configured in `.env`:
 - `ALERT_PORT`: Port for the alert manager API (default: `8090`)
 - `DISCORD_WEBHOOK_URL`: Discord webhook URL for sending notifications
 - `DISCORD_ENABLED`: Enable/disable Discord notifications (default: `false`)
-- `MINECRAFT_RCON_HOST`: Minecraft server hostname for RCON (default: `mcserver`)
+- `MINECRAFT_RCON_HOST`: Minecraft server hostname for RCON (Docker Compose default: `minecraft-wrapper`; the application's built-in fallback when unset is `mcserver`)
 - `MINECRAFT_RCON_PORT`: Minecraft server RCON port (default: `25575`)
 - `MINECRAFT_RCON_PASSWORD`: Password for Minecraft RCON (default: uses `RCON_PASSWORD` from compose.yml)
 - `MINECRAFT_RCON_ENABLED`: Enable/disable Minecraft message sending (default: `true`)

--- a/alert-manager/README.md
+++ b/alert-manager/README.md
@@ -20,7 +20,7 @@ The following environment variables can be configured in `.env`:
 - `ALERT_PORT`: Port for the alert manager API (default: `8090`)
 - `DISCORD_WEBHOOK_URL`: Discord webhook URL for sending notifications
 - `DISCORD_ENABLED`: Enable/disable Discord notifications (default: `false`)
-- `MINECRAFT_RCON_HOST`: Minecraft server hostname for RCON (default: `minecraft-wrapper`)
+- `MINECRAFT_RCON_HOST`: Minecraft server hostname for RCON (default: `mcserver`)
 - `MINECRAFT_RCON_PORT`: Minecraft server RCON port (default: `25575`)
 - `MINECRAFT_RCON_PASSWORD`: Password for Minecraft RCON (default: uses `RCON_PASSWORD` from compose.yml)
 - `MINECRAFT_RCON_ENABLED`: Enable/disable Minecraft message sending (default: `true`)
@@ -40,7 +40,7 @@ To enable Discord notifications:
 
 ### Minecraft RCON Setup
 
-The alert manager can send messages directly to the Minecraft server using RCON. This is enabled by default and uses the same RCON password configured for the Minecraft server. The minecraft-wrapper script uses this functionality to send shutdown warnings to players.
+The alert manager can send messages directly to the Minecraft server using RCON. This is enabled by default and uses the same RCON password configured for the Minecraft server. The minecraft-wrapper service uses this functionality to send shutdown warnings to players.
 
 ## Alert Levels
 

--- a/backup-manager/README.md
+++ b/backup-manager/README.md
@@ -141,6 +141,11 @@ The backup-manager exposes a REST API on port 8091 (configurable via `BACKUP_POR
 - Returns JSON response with backup status and location
 - HTTP 200 on success, 500 on failure
 
+**GET /api/backups/latest**
+- Returns metadata about the most recent backup. Always HTTP 200; when no
+  backup has been performed yet the response body is
+  `{"available": false, "message": "No backup has been performed yet"}`.
+
 ## Volume Mounts
 
 The backup-manager container has access to:
@@ -151,7 +156,11 @@ The backup-manager container has access to:
 ## Security Notes
 
 - The Minecraft server volume is mounted read-only for safety
-- The REST API is exposed on localhost by default (port 8091)
+- The REST API listens on port 8091 inside the container. By default Docker
+  Compose publishes it as `${BACKUP_PORT:-8091}:8091` with no bind address,
+  which means **all host interfaces** — not just localhost. If you don't need
+  external access to the backup API, restrict the binding (e.g.
+  `"127.0.0.1:${BACKUP_PORT:-8091}:8091"`) or block the port at your firewall.
 
 ## Troubleshooting
 

--- a/helm/omcsi/templates/minecraft-wrapper.yaml
+++ b/helm/omcsi/templates/minecraft-wrapper.yaml
@@ -169,6 +169,9 @@ spec:
       targetPort: minecraft
       protocol: TCP
       name: minecraft
+      {{- if and (eq .Values.minecraftWrapper.service.type "NodePort") .Values.minecraftWrapper.service.nodePort }}
+      nodePort: {{ .Values.minecraftWrapper.service.nodePort }}
+      {{- end }}
   selector:
     {{- include "omcsi.selectorLabels" (dict "root" . "component" "minecraft-wrapper") | nindent 4 }}
 ---

--- a/helm/omcsi/templates/nginx.yaml
+++ b/helm/omcsi/templates/nginx.yaml
@@ -123,9 +123,15 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+      {{- if and (eq .Values.nginx.service.type "NodePort") .Values.nginx.service.httpNodePort }}
+      nodePort: {{ .Values.nginx.service.httpNodePort }}
+      {{- end }}
     - port: {{ .Values.nginx.service.httpsPort }}
       targetPort: https
       protocol: TCP
       name: https
+      {{- if and (eq .Values.nginx.service.type "NodePort") .Values.nginx.service.httpsNodePort }}
+      nodePort: {{ .Values.nginx.service.httpsNodePort }}
+      {{- end }}
   selector:
     {{- include "omcsi.selectorLabels" (dict "root" . "component" "nginx") | nindent 4 }}

--- a/helm/omcsi/tests/minecraft_wrapper_test.yaml
+++ b/helm/omcsi/tests/minecraft_wrapper_test.yaml
@@ -148,6 +148,31 @@ tests:
           value: LoadBalancer
         documentIndex: 1
 
+  - it: external service has no fixed nodePort by default
+    asserts:
+      - notExists:
+          path: spec.ports[0].nodePort
+        documentIndex: 1
+
+  - it: external service nodePort is pinned when set on a NodePort service
+    set:
+      minecraftWrapper.service.type: NodePort
+      minecraftWrapper.service.nodePort: 25565
+    asserts:
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 25565
+        documentIndex: 1
+
+  - it: external service nodePort is ignored for non-NodePort service types
+    set:
+      minecraftWrapper.service.type: LoadBalancer
+      minecraftWrapper.service.nodePort: 25565
+    asserts:
+      - notExists:
+          path: spec.ports[0].nodePort
+        documentIndex: 1
+
   - it: uses emptyDir for mcserver volume when persistence is disabled
     set:
       persistence.mcserver.enabled: false

--- a/helm/omcsi/tests/nginx_test.yaml
+++ b/helm/omcsi/tests/nginx_test.yaml
@@ -13,6 +13,7 @@ tests:
     documentSelector:
       path: kind
       value: Service
+      skipEmptyTemplates: true
     asserts:
       - equal:
           path: spec.type
@@ -28,6 +29,7 @@ tests:
     documentSelector:
       path: kind
       value: Service
+      skipEmptyTemplates: true
     asserts:
       - notExists:
           path: spec.ports[0].nodePort
@@ -42,6 +44,7 @@ tests:
     documentSelector:
       path: kind
       value: Service
+      skipEmptyTemplates: true
     asserts:
       - equal:
           path: spec.type
@@ -61,6 +64,7 @@ tests:
     documentSelector:
       path: kind
       value: Service
+      skipEmptyTemplates: true
     asserts:
       - notExists:
           path: spec.ports[0].nodePort

--- a/helm/omcsi/tests/nginx_test.yaml
+++ b/helm/omcsi/tests/nginx_test.yaml
@@ -1,0 +1,65 @@
+suite: nginx
+templates:
+  - templates/nginx.yaml
+set:
+  secrets.rconPassword: ci
+  secrets.adminPassword: ci
+tests:
+  - it: service is a LoadBalancer exposing HTTP and HTTPS by default
+    asserts:
+      - isKind:
+          of: Service
+        documentIndex: 1
+      - equal:
+          path: spec.type
+          value: LoadBalancer
+        documentIndex: 1
+      - equal:
+          path: spec.ports[0].port
+          value: 80
+        documentIndex: 1
+      - equal:
+          path: spec.ports[1].port
+          value: 443
+        documentIndex: 1
+
+  - it: service has no fixed nodePorts by default
+    asserts:
+      - notExists:
+          path: spec.ports[0].nodePort
+        documentIndex: 1
+      - notExists:
+          path: spec.ports[1].nodePort
+        documentIndex: 1
+
+  - it: nodePorts are pinned when set on a NodePort service
+    set:
+      nginx.service.type: NodePort
+      nginx.service.httpNodePort: 80
+      nginx.service.httpsNodePort: 443
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+        documentIndex: 1
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 80
+        documentIndex: 1
+      - equal:
+          path: spec.ports[1].nodePort
+          value: 443
+        documentIndex: 1
+
+  - it: nodePorts are ignored for non-NodePort service types
+    set:
+      nginx.service.type: LoadBalancer
+      nginx.service.httpNodePort: 80
+      nginx.service.httpsNodePort: 443
+    asserts:
+      - notExists:
+          path: spec.ports[0].nodePort
+        documentIndex: 1
+      - notExists:
+          path: spec.ports[1].nodePort
+        documentIndex: 1

--- a/helm/omcsi/tests/nginx_test.yaml
+++ b/helm/omcsi/tests/nginx_test.yaml
@@ -1,65 +1,68 @@
 suite: nginx
+# nginx.yaml references nginx-configmap.yaml (checksum annotation), so both
+# templates must be rendered together. Service assertions use documentSelector
+# to target the Service by kind, independent of document order.
 templates:
   - templates/nginx.yaml
+  - templates/nginx-configmap.yaml
 set:
   secrets.rconPassword: ci
   secrets.adminPassword: ci
 tests:
   - it: service is a LoadBalancer exposing HTTP and HTTPS by default
+    documentSelector:
+      path: kind
+      value: Service
     asserts:
-      - isKind:
-          of: Service
-        documentIndex: 1
       - equal:
           path: spec.type
           value: LoadBalancer
-        documentIndex: 1
       - equal:
           path: spec.ports[0].port
           value: 80
-        documentIndex: 1
       - equal:
           path: spec.ports[1].port
           value: 443
-        documentIndex: 1
 
   - it: service has no fixed nodePorts by default
+    documentSelector:
+      path: kind
+      value: Service
     asserts:
       - notExists:
           path: spec.ports[0].nodePort
-        documentIndex: 1
       - notExists:
           path: spec.ports[1].nodePort
-        documentIndex: 1
 
   - it: nodePorts are pinned when set on a NodePort service
     set:
       nginx.service.type: NodePort
       nginx.service.httpNodePort: 80
       nginx.service.httpsNodePort: 443
+    documentSelector:
+      path: kind
+      value: Service
     asserts:
       - equal:
           path: spec.type
           value: NodePort
-        documentIndex: 1
       - equal:
           path: spec.ports[0].nodePort
           value: 80
-        documentIndex: 1
       - equal:
           path: spec.ports[1].nodePort
           value: 443
-        documentIndex: 1
 
   - it: nodePorts are ignored for non-NodePort service types
     set:
       nginx.service.type: LoadBalancer
       nginx.service.httpNodePort: 80
       nginx.service.httpsNodePort: 443
+    documentSelector:
+      path: kind
+      value: Service
     asserts:
       - notExists:
           path: spec.ports[0].nodePort
-        documentIndex: 1
       - notExists:
           path: spec.ports[1].nodePort
-        documentIndex: 1

--- a/helm/omcsi/values.yaml
+++ b/helm/omcsi/values.yaml
@@ -43,6 +43,13 @@ minecraftWrapper:
     # External service exposes only the Minecraft game port.
     type: NodePort
     minecraftPort: 25565
+    # Optional fixed NodePort for the Minecraft game port. Only applied when
+    # type is "NodePort". Leave empty to let Kubernetes auto-assign a port from
+    # the cluster's service-node-port-range (default 30000-32767). To serve the
+    # standard 25565 directly on the node IP (single-node / bare-VPS setups),
+    # set this to 25565 AND widen the apiserver --service-node-port-range to
+    # include it (e.g. 80-32767). See terraform/hetzner for a worked example.
+    nodePort: ""
   # Internal ClusterIP service for RCON, BlueMap, and wrapper API.
   internalService:
     rconPort: 25575
@@ -129,6 +136,13 @@ nginx:
     type: LoadBalancer
     httpPort: 80
     httpsPort: 443
+    # Optional fixed NodePorts for HTTP/HTTPS. Only applied when type is
+    # "NodePort". Leave empty to let Kubernetes auto-assign. To serve the
+    # dashboard on standard 80/443 directly on the node IP (single-node /
+    # bare-VPS setups), set these AND widen the apiserver
+    # --service-node-port-range to include them (e.g. 80-32767).
+    httpNodePort: ""
+    httpsNodePort: ""
   tls:
     # When true, a self-signed certificate is generated via an init container
     # (same behaviour as the Docker Compose setup).

--- a/minecraft-wrapper/README.md
+++ b/minecraft-wrapper/README.md
@@ -6,8 +6,8 @@ A Spring Boot service that manages the Minecraft server lifecycle, providing gra
 
 This module replaces the original `minecraft-wrapper.sh` bash script with a testable, maintainable Spring Boot application. It is integrated into the main Minecraft server container and provides:
 
-- **Testable Logic**: All wrapper functionality is covered by unit tests (15 tests)
-- **REST API**: Exposes endpoints for server management and messaging
+- **Testable Logic**: All wrapper functionality is covered by unit and controller tests
+- **REST API**: Exposes endpoints for server management, plugin deployment, and messaging
 - **Service Integration**: Other services can interact with the wrapper via HTTP
 
 ## Features
@@ -15,8 +15,8 @@ This module replaces the original `minecraft-wrapper.sh` bash script with a test
 - **Server Lifecycle Management**: Automatically starts and manages the Minecraft server process
 - **Graceful Shutdown**: Warns players with countdown messages before shutting down
 - **Alert Integration**: Sends alerts to the alert-manager service for server events (start, stop, crash)
-- **REST API**: Exposes endpoints for server status, command execution, and message sending
-- **Unit Tests**: Comprehensive test coverage for all service components (15 tests)
+- **REST API**: Exposes endpoints for server status, command execution, message sending, plugin deployment, and log/metrics retrieval
+- **Unit & Controller Tests**: Comprehensive test coverage across service and controller layers
 
 ## Deployment
 
@@ -63,6 +63,16 @@ The Spring Boot wrapper is built as part of the main Minecraft server Docker ima
   curl -X POST http://localhost:8092/api/server/shutdown
   ```
 
+- `GET /api/server/logs` - Retrieve recent server log lines
+  ```bash
+  curl http://localhost:8092/api/server/logs
+  ```
+
+- `GET /api/server/metrics` - Retrieve server resource metrics (memory, TPS)
+  ```bash
+  curl http://localhost:8092/api/server/metrics
+  ```
+
 ### Messaging
 
 - `POST /api/messages` - Send a message to players
@@ -71,6 +81,14 @@ The Spring Boot wrapper is built as part of the main Minecraft server Docker ima
     -H "Content-Type: application/json" \
     -d '{"text": "Server maintenance in 5 minutes", "destination": "MINECRAFT"}'
   ```
+
+### Plugin Deployment
+
+- `POST /api/plugins/deploy` - Deploy a plugin JAR to the server's `plugins/` directory.
+  Used by the [`deploy-plugin.yml`](../docs/github-actions/deploy-plugin.yml)
+  GitHub Actions workflow to ship plugin builds from CI to the server. See the
+  [`PluginDeployController`](src/main/java/com/openmc/minecraftwrapper/controller/PluginDeployController.java)
+  source for the request schema and authentication requirements.
 
 ## Configuration
 
@@ -118,11 +136,14 @@ alerts.server.crash=true
 ./gradlew test
 ```
 
-All tests pass, providing confidence in the wrapper logic:
-- AlertServiceTest: 8 tests
-- MessageServiceTest: 4 tests  
-- ShutdownServiceTest: 2 tests
-- MinecraftWrapperApplicationTest: 1 test
+Tests are split across the service and controller layers — run `./gradlew test`
+to see the current count and breakdown. The current suite covers, at minimum:
+
+- Service layer: `AlertServiceTest`, `MessageServiceTest`, `ShutdownServiceTest`,
+  `PluginDeployServiceTest`
+- Controller layer: `ServerControllerTest`, `MessageControllerTest`,
+  `PluginDeployControllerTest`
+- Application bootstrapping: `MinecraftWrapperApplicationTest`
 
 ## Integration with Infrastructure
 
@@ -137,7 +158,7 @@ The wrapper service is built and deployed as part of the main Minecraft server c
 
 The Spring Boot wrapper replaces the previous bash script with these benefits:
 
-- ✅ **Unit tested**: 15 tests covering all core logic
+- ✅ **Unit tested**: service and controller layers covered by JUnit tests
 - ✅ **REST API**: Remote management capabilities
 - ✅ **Better error handling**: Structured logging and exception handling
 - ✅ **Maintainable**: Easier to extend and modify

--- a/sample.env
+++ b/sample.env
@@ -34,6 +34,8 @@ HOST_PORT=25565
 HOST_RCON_PORT=25575
 # BlueMap port (default: 8100)
 HOST_BLUEMAP_PORT=8100
+# Minecraft wrapper REST API port (default: 8092) — change when running parallel servers
+WRAPPER_PORT=8092
 
 # Volume name - change this to use separate data for parallel servers
 VOLUME_NAME=mcserver

--- a/terraform/COST_ANALYSIS.md
+++ b/terraform/COST_ANALYSIS.md
@@ -1,10 +1,49 @@
-# Kubernetes Cost Analysis: LKE (Linode) vs EKS (AWS)
+# Kubernetes Cost Analysis: Hetzner vs LKE (Linode) vs EKS (AWS)
 
-This document summarizes the monthly cost difference between the two supported Terraform deployment targets: Linode Kubernetes Engine (LKE) and AWS Elastic Kubernetes Service (EKS).
+This document summarizes the monthly cost difference between the supported Terraform deployment targets: a **self-managed single node on Hetzner Cloud** (`terraform/hetzner/`), Linode Kubernetes Engine (LKE), and AWS Elastic Kubernetes Service (EKS).
 
 ## TL;DR
 
-For equivalent workloads, **LKE is roughly 2–3× cheaper than EKS** at small-to-medium cluster sizes. The primary driver is EKS's mandatory $73/month control plane fee per cluster, which LKE does not charge.
+OMCSI is a **single Minecraft server plus a handful of small Spring Boot services** — its real footprint is roughly 5 GB of RAM, not the 16 GB the managed-cluster defaults provision. Most of the cost on managed Kubernetes is *infrastructure tax* that the workload never asked for: a control-plane fee, a cloud LoadBalancer, a NAT gateway, and oversized nodes.
+
+If you are willing to self-manage the cluster (kubeadm), a **single Hetzner CAX31 runs the whole stack for ~$14/month — under the $20 target and ~8–18× cheaper than the managed options.** It carries none of the managed-Kubernetes line items: no control-plane fee, no cloud LoadBalancer (services are exposed via NodePorts on the node's public IP), and no NAT gateway.
+
+For equivalent *managed* workloads, **LKE is roughly 2–3× cheaper than EKS**, driven mainly by EKS's mandatory $73/month control-plane fee per cluster, which LKE does not charge.
+
+| Deployment target | Control plane | What you manage | Est. total |
+|---|---|---|---|
+| **Hetzner CAX31 (self-managed kubeadm)** | $0 (on the node) | The cluster (CKA-style) | **~$14/mo** |
+| LKE (managed) | $0 | Apps only | ~$109/mo |
+| EKS (managed) | $73 | Apps only | ~$248/mo |
+
+---
+
+## Self-Managed Single Node (Hetzner) — Cheapest
+
+The `terraform/hetzner/` module provisions one Hetzner Cloud server, bootstraps a single-node Kubernetes cluster with `kubeadm` (containerd, Calico CNI, `local-path` default StorageClass, control-plane untainted), and deploys the same OMCSI Helm chart all targets share.
+
+| Component | Cost | Notes |
+|---|---|---|
+| Control plane | **$0** | Runs on the same node (untainted control plane) |
+| Server (1× cax31) | **~€12.49 (~$14)** | Ampere ARM64, 8 vCPU / 16 GB / 160 GB NVMe |
+| Load balancer | **$0** | NodePorts pinned to 25565/80/443 on the node's public IP (apiserver `--service-node-port-range` widened to `80-32767`) |
+| NAT gateway | **$0** | Node has a public IP directly |
+| Egress | **$0** | Hetzner bundles 20 TB/mo |
+| Block storage | **$0** | `local-path` provisioner uses the node's included NVMe |
+| **Estimated total** | **~$14/mo** | |
+
+**Cheaper / alternative hosts** (the module's `server_type` / `location` cover Hetzner; the same kubeadm approach applies elsewhere):
+
+| Host | Specs | Cost | Notes |
+|---|---|---|---|
+| Oracle Cloud Always Free (Ampere A1) | 4 OCPU / 24 GB | **$0** | Free forever, but ARM + frequent "Out of Capacity"; needs multi-arch images |
+| Hetzner CAX31 (default) | 8 vCPU / 16 GB | ~$14 | Best price/performance; ARM |
+| Hetzner CPX31 | 4 vCPU / 8 GB | ~$9–18 | x86; tighter RAM but sufficient |
+| Contabo VPS 10 | 4 vCPU / 8 GB | ~$5–7 | Cheapest; weaker CPU/disk (fine for 5–10 players) |
+
+> **ARM note:** The cheapest Hetzner (CAX) and the free Oracle tier are ARM64. The project's published images are multi-arch (`linux/amd64,linux/arm64`), so they run on ARM out of the box. If you fork and publish your own images, keep the `platforms:` flag in `.github/workflows/docker-publish.yml`.
+
+> **Trade-off:** You own cluster operations — upgrades, etcd backups, node maintenance, and single-node availability (no HA). This is the explicit deal for the lower price, and it maps cleanly onto CKA-style skills (kubeadm, CNI, taints, NodePort/`service-node-port-range`, StorageClasses).
 
 ---
 
@@ -72,6 +111,12 @@ Linode shared instances are significantly cheaper than AWS on-demand instances f
 ---
 
 ## When to Choose Each Provider
+
+### Choose Hetzner self-managed (`terraform/hetzner/`) when:
+- Cost is the top priority and you want to stay under ~$20/month
+- You're comfortable operating the cluster yourself (kubeadm, upgrades, backups)
+- A single node without HA is acceptable for your community size
+- You want the cheapest path that still uses the standard OMCSI Helm chart
 
 ### Choose LKE (Linode) when:
 - Cost is the primary concern

--- a/terraform/hetzner/cloud-init.sh.tftpl
+++ b/terraform/hetzner/cloud-init.sh.tftpl
@@ -1,0 +1,117 @@
+#!/bin/bash
+# =============================================================================
+# OMCSI single-node Kubernetes bootstrap (kubeadm) for Hetzner Cloud
+# =============================================================================
+# Rendered by Terraform (templatefile) and passed as the server's user_data.
+# Brings up a single-node cluster suitable for one OMCSI deployment:
+#   - containerd + kubeadm/kubelet/kubectl (pinned minor version)
+#   - Calico CNI (supports NetworkPolicy, which the OMCSI chart relies on)
+#   - control-plane node untainted so workloads schedule on it
+#   - local-path-provisioner as the default StorageClass (PVCs need this)
+#   - service-node-port-range widened so NodePort can bind 25565/80/443
+#   - Helm installed for the Terraform-driven app deploy that follows
+#
+# On success it writes /var/lib/omcsi-bootstrap-complete; Terraform polls for
+# that sentinel before deploying the Helm chart. Full log: /var/log/omcsi-bootstrap.log
+# =============================================================================
+set -euxo pipefail
+exec > >(tee -a /var/log/omcsi-bootstrap.log) 2>&1
+
+export DEBIAN_FRONTEND=noninteractive
+KUBERNETES_VERSION="${kubernetes_version}"
+POD_CIDR="${pod_cidr}"
+SERVICE_NODE_PORT_RANGE="${service_node_port_range}"
+CALICO_VERSION="${calico_version}"
+LOCAL_PATH_PROVISIONER_VERSION="${local_path_provisioner_version}"
+
+# Hetzner metadata service exposes the public IPv4 so we can add it to the API
+# server certificate SANs — this makes the fetched kubeconfig valid remotely.
+PUBLIC_IP="$(curl -fsS --retry 6 --retry-delay 5 http://169.254.169.254/hetzner/v1/metadata/public-ipv4)"
+
+# --- Kernel prerequisites -----------------------------------------------------
+swapoff -a || true
+sed -i '/ swap / s/^/#/' /etc/fstab || true
+cat <<'EOF' >/etc/modules-load.d/k8s.conf
+overlay
+br_netfilter
+EOF
+modprobe overlay
+modprobe br_netfilter
+cat <<'EOF' >/etc/sysctl.d/k8s.conf
+net.bridge.bridge-nf-call-iptables  = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+net.ipv4.ip_forward                 = 1
+EOF
+sysctl --system
+
+# --- Container runtime (containerd) ------------------------------------------
+apt-get update
+apt-get install -y apt-transport-https ca-certificates curl gpg containerd
+mkdir -p /etc/containerd
+containerd config default >/etc/containerd/config.toml
+# kubelet and containerd must agree on the systemd cgroup driver.
+sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
+systemctl restart containerd
+systemctl enable containerd
+
+# --- kubeadm / kubelet / kubectl ---------------------------------------------
+mkdir -p /etc/apt/keyrings
+curl -fsSL "https://pkgs.k8s.io/core:/stable:/v$${KUBERNETES_VERSION}/deb/Release.key" |
+  gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v$${KUBERNETES_VERSION}/deb/ /" \
+  >/etc/apt/sources.list.d/kubernetes.list
+apt-get update
+apt-get install -y kubelet kubeadm kubectl
+apt-mark hold kubelet kubeadm kubectl
+systemctl enable kubelet
+
+# --- Initialise the control plane --------------------------------------------
+cat <<EOF >/root/kubeadm-config.yaml
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: InitConfiguration
+nodeRegistration:
+  criSocket: unix:///run/containerd/containerd.sock
+---
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: ClusterConfiguration
+kubernetesVersion: stable-$${KUBERNETES_VERSION}
+networking:
+  podSubnet: $${POD_CIDR}
+apiServer:
+  certSANs:
+    - $${PUBLIC_IP}
+  extraArgs:
+    - name: service-node-port-range
+      value: "$${SERVICE_NODE_PORT_RANGE}"
+EOF
+kubeadm init --config /root/kubeadm-config.yaml
+
+# --- kubectl access for root --------------------------------------------------
+mkdir -p /root/.kube
+cp -f /etc/kubernetes/admin.conf /root/.kube/config
+export KUBECONFIG=/etc/kubernetes/admin.conf
+
+# --- Calico CNI (NetworkPolicy-capable; required by the OMCSI chart) ----------
+kubectl create -f "https://raw.githubusercontent.com/projectcalico/calico/$${CALICO_VERSION}/manifests/tigera-operator.yaml"
+# custom-resources.yaml defaults its IP pool to 192.168.0.0/16 — keep POD_CIDR
+# aligned with that (the Terraform default does).
+curl -fsSL "https://raw.githubusercontent.com/projectcalico/calico/$${CALICO_VERSION}/manifests/custom-resources.yaml" \
+  | sed "s#192.168.0.0/16#$${POD_CIDR}#g" | kubectl create -f -
+
+# --- Single node: allow workloads on the control plane ------------------------
+kubectl taint nodes --all node-role.kubernetes.io/control-plane- || true
+
+# --- Default StorageClass (PVCs stay Pending without one) ---------------------
+kubectl apply -f "https://raw.githubusercontent.com/rancher/local-path-provisioner/$${LOCAL_PATH_PROVISIONER_VERSION}/deploy/local-path-storage.yaml"
+kubectl patch storageclass local-path \
+  -p '{"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+
+# --- Helm ---------------------------------------------------------------------
+curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+# --- Wait for the node and core services to be Ready --------------------------
+kubectl wait --for=condition=Ready node --all --timeout=600s
+kubectl -n kube-system rollout status deployment/coredns --timeout=600s
+
+touch /var/lib/omcsi-bootstrap-complete
+echo "OMCSI bootstrap complete on $${PUBLIC_IP}"

--- a/terraform/hetzner/main.tf
+++ b/terraform/hetzner/main.tf
@@ -150,7 +150,7 @@ resource "null_resource" "deploy" {
     type        = "ssh"
     host        = hcloud_server.omcsi.ipv4_address
     user        = "root"
-    private_key = file(var.ssh_private_key_path)
+    private_key = file(pathexpand(var.ssh_private_key_path))
     timeout     = "10m"
   }
 
@@ -196,7 +196,7 @@ resource "null_resource" "kubeconfig" {
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
     command     = <<-EOT
-      ssh -i '${var.ssh_private_key_path}' -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+      ssh -i '${pathexpand(var.ssh_private_key_path)}' -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
         root@${hcloud_server.omcsi.ipv4_address} 'cat /etc/kubernetes/admin.conf' \
         | sed 's#server: https://[^:]*:6443#server: https://${hcloud_server.omcsi.ipv4_address}:6443#' \
         > '${path.module}/kubeconfig.yaml'

--- a/terraform/hetzner/main.tf
+++ b/terraform/hetzner/main.tf
@@ -1,0 +1,206 @@
+# =============================================================================
+# OMCSI on a single self-managed Hetzner Cloud server (kubeadm + Helm)
+# =============================================================================
+# Design note: unlike the LKE/EKS modules — which deploy the chart through the
+# Helm provider because the managed cluster exposes API credentials as resource
+# attributes — a freshly kubeadm-bootstrapped node has no such attributes at
+# plan time. To keep this a reliable single `terraform apply`, the chart is
+# deployed over SSH from the node itself (upload chart + rendered values, run
+# `helm upgrade --install`). The OMCSI Helm chart is the same one all targets
+# share; only the delivery mechanism differs.
+# =============================================================================
+
+provider "hcloud" {
+  token = var.hcloud_token
+}
+
+locals {
+  discord_enabled = var.discord_webhook_url != "" ? "true" : "false"
+
+  cloud_init = templatefile("${path.module}/cloud-init.sh.tftpl", {
+    kubernetes_version             = var.kubernetes_version
+    pod_cidr                       = var.pod_cidr
+    service_node_port_range        = var.service_node_port_range
+    calico_version                 = var.calico_version
+    local_path_provisioner_version = var.local_path_provisioner_version
+  })
+
+  helm_values = templatefile("${path.module}/values.yaml.tftpl", {
+    rcon_password            = var.rcon_password
+    admin_password           = var.admin_password
+    image_registry           = var.image_registry
+    minecraft_nodeport       = var.minecraft_node_port
+    http_nodeport            = var.http_node_port
+    https_nodeport           = var.https_node_port
+    storage_class            = var.storage_class
+    minecraft_version        = var.minecraft_version
+    operator_uuid            = var.operator_uuid
+    operator_name            = var.operator_name
+    server_motd              = var.server_motd
+    max_players              = var.max_players
+    java_opts                = var.java_opts
+    discord_enabled          = local.discord_enabled
+    discord_webhook_url      = var.discord_webhook_url
+    deploy_auth_token        = var.deploy_auth_token
+    agent_manager_enabled    = var.agent_manager_enabled
+    agent_discord_bot_token  = var.agent_discord_bot_token
+    agent_discord_channel_id = var.agent_discord_channel_id
+    agent_anthropic_api_key  = var.agent_anthropic_api_key
+  })
+}
+
+# --- SSH key ------------------------------------------------------------------
+resource "hcloud_ssh_key" "omcsi" {
+  name       = "${var.server_name}-key"
+  public_key = var.ssh_public_key
+}
+
+# --- Firewall -----------------------------------------------------------------
+# SSH and the Kubernetes API are restricted to allowed_ssh_cidr; the game and
+# dashboard ports are public. Egress is unrestricted (no "out" rules).
+resource "hcloud_firewall" "omcsi" {
+  name = "${var.server_name}-fw"
+
+  rule {
+    description = "SSH"
+    direction   = "in"
+    protocol    = "tcp"
+    port        = "22"
+    source_ips  = [var.allowed_ssh_cidr]
+  }
+
+  rule {
+    description = "Kubernetes API"
+    direction   = "in"
+    protocol    = "tcp"
+    port        = "6443"
+    source_ips  = [var.allowed_ssh_cidr]
+  }
+
+  rule {
+    description = "Minecraft game port"
+    direction   = "in"
+    protocol    = "tcp"
+    port        = tostring(var.minecraft_node_port)
+    source_ips  = ["0.0.0.0/0", "::/0"]
+  }
+
+  rule {
+    description = "Dashboard HTTP"
+    direction   = "in"
+    protocol    = "tcp"
+    port        = tostring(var.http_node_port)
+    source_ips  = ["0.0.0.0/0", "::/0"]
+  }
+
+  rule {
+    description = "Dashboard HTTPS"
+    direction   = "in"
+    protocol    = "tcp"
+    port        = tostring(var.https_node_port)
+    source_ips  = ["0.0.0.0/0", "::/0"]
+  }
+}
+
+# --- Server -------------------------------------------------------------------
+resource "hcloud_server" "omcsi" {
+  name         = var.server_name
+  server_type  = var.server_type
+  image        = var.server_image
+  location     = var.location
+  user_data    = local.cloud_init
+  ssh_keys     = [hcloud_ssh_key.omcsi.id]
+  firewall_ids = [hcloud_firewall.omcsi.id]
+
+  labels = {
+    app = "omcsi"
+  }
+
+  public_net {
+    ipv4_enabled = true
+    ipv6_enabled = true
+  }
+}
+
+# --- Deploy OMCSI via Helm from the node --------------------------------------
+resource "null_resource" "deploy" {
+  triggers = {
+    server_id    = hcloud_server.omcsi.id
+    values_sha   = sha256(local.helm_values)
+    release_name = var.helm_release_name
+    namespace    = var.helm_namespace
+  }
+
+  lifecycle {
+    precondition {
+      condition     = !var.agent_manager_enabled || var.agent_discord_bot_token != ""
+      error_message = "agent_discord_bot_token is required when agent_manager_enabled is true."
+    }
+    precondition {
+      condition     = !var.agent_manager_enabled || var.agent_discord_channel_id != ""
+      error_message = "agent_discord_channel_id is required when agent_manager_enabled is true."
+    }
+    precondition {
+      condition     = !var.agent_manager_enabled || var.agent_anthropic_api_key != ""
+      error_message = "agent_anthropic_api_key is required when agent_manager_enabled is true."
+    }
+  }
+
+  connection {
+    type        = "ssh"
+    host        = hcloud_server.omcsi.ipv4_address
+    user        = "root"
+    private_key = file(var.ssh_private_key_path)
+    timeout     = "10m"
+  }
+
+  # Wait for the kubeadm bootstrap (cloud-init) to finish.
+  provisioner "remote-exec" {
+    inline = [
+      "echo 'Waiting for Kubernetes bootstrap to complete...'",
+      "for i in $(seq 1 120); do [ -f /var/lib/omcsi-bootstrap-complete ] && break; sleep 15; done",
+      "test -f /var/lib/omcsi-bootstrap-complete || { echo 'Bootstrap did not complete in time; see /var/log/omcsi-bootstrap.log'; exit 1; }",
+      "mkdir -p /opt/omcsi/chart",
+    ]
+  }
+
+  # Upload the OMCSI Helm chart (contents) and the rendered values file.
+  provisioner "file" {
+    source      = "${path.module}/../../helm/omcsi/"
+    destination = "/opt/omcsi/chart"
+  }
+
+  provisioner "file" {
+    content     = local.helm_values
+    destination = "/opt/omcsi/values.yaml"
+  }
+
+  # Install / upgrade the release.
+  provisioner "remote-exec" {
+    inline = [
+      "chmod 600 /opt/omcsi/values.yaml",
+      "export KUBECONFIG=/etc/kubernetes/admin.conf",
+      "helm upgrade --install ${var.helm_release_name} /opt/omcsi/chart --namespace ${var.helm_namespace} --create-namespace -f /opt/omcsi/values.yaml --wait --timeout 15m",
+    ]
+  }
+}
+
+# --- Fetch a kubeconfig pointing at the public IP -----------------------------
+resource "null_resource" "kubeconfig" {
+  depends_on = [null_resource.deploy]
+
+  triggers = {
+    server_id = hcloud_server.omcsi.id
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command     = <<-EOT
+      ssh -i '${var.ssh_private_key_path}' -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+        root@${hcloud_server.omcsi.ipv4_address} 'cat /etc/kubernetes/admin.conf' \
+        | sed 's#server: https://[^:]*:6443#server: https://${hcloud_server.omcsi.ipv4_address}:6443#' \
+        > '${path.module}/kubeconfig.yaml'
+      chmod 600 '${path.module}/kubeconfig.yaml'
+    EOT
+  }
+}

--- a/terraform/hetzner/outputs.tf
+++ b/terraform/hetzner/outputs.tf
@@ -1,0 +1,43 @@
+# =============================================================================
+# Outputs
+# =============================================================================
+
+output "server_ipv4" {
+  description = "Public IPv4 address of the OMCSI server."
+  value       = hcloud_server.omcsi.ipv4_address
+}
+
+output "server_ipv6" {
+  description = "Public IPv6 address of the OMCSI server."
+  value       = hcloud_server.omcsi.ipv6_address
+}
+
+output "minecraft_address" {
+  description = "Connect your Minecraft client to this address."
+  value       = "${hcloud_server.omcsi.ipv4_address}:${var.minecraft_node_port}"
+}
+
+output "dashboard_url" {
+  description = "OMCSI web dashboard URL (self-signed cert by default — expect a browser warning)."
+  value       = var.https_node_port == 443 ? "https://${hcloud_server.omcsi.ipv4_address}" : "https://${hcloud_server.omcsi.ipv4_address}:${var.https_node_port}"
+}
+
+output "ssh_command" {
+  description = "SSH into the server."
+  value       = "ssh -i ${var.ssh_private_key_path} root@${hcloud_server.omcsi.ipv4_address}"
+}
+
+output "kubeconfig_path" {
+  description = "Path to the generated kubeconfig (API access is restricted to allowed_ssh_cidr)."
+  value       = "${path.module}/kubeconfig.yaml"
+}
+
+output "kubectl_hint" {
+  description = "Use the generated kubeconfig with kubectl."
+  value       = "export KUBECONFIG=${path.module}/kubeconfig.yaml && kubectl get pods -n ${var.helm_namespace}"
+}
+
+output "estimated_monthly_cost" {
+  description = "Rough monthly infrastructure cost (server type dependent; cax31 default ≈ EUR 12.49)."
+  value       = "Server type '${var.server_type}' in '${var.location}'. cax31 ≈ EUR 12.49/mo (~$14), well under the $20 target. No control-plane, LoadBalancer, or NAT charges."
+}

--- a/terraform/hetzner/terraform.tfvars.example
+++ b/terraform/hetzner/terraform.tfvars.example
@@ -1,0 +1,57 @@
+# =============================================================================
+# Example Terraform variables for OMCSI on a single Hetzner Cloud server
+# =============================================================================
+# Copy to terraform.tfvars and fill in the values:
+#   cp terraform.tfvars.example terraform.tfvars
+#
+# Or export the token and pass the rest via -var:
+#   export TF_VAR_hcloud_token="your-hetzner-api-token"
+#   terraform apply -var rcon_password=changeme -var admin_password=strongpass \
+#     -var ssh_public_key="$(cat ~/.ssh/id_ed25519.pub)" \
+#     -var ssh_private_key_path="$HOME/.ssh/id_ed25519"
+# =============================================================================
+
+# Hetzner Cloud API token (required) — Project → Security → API Tokens (Read & Write)
+hcloud_token = "your-hetzner-api-token"
+
+# SSH access (required) — Terraform bootstraps and deploys over SSH
+ssh_public_key       = "ssh-ed25519 AAAA... you@host"
+ssh_private_key_path = "~/.ssh/id_ed25519"
+
+# Lock SSH + Kubernetes API to your own IP (strongly recommended).
+# Game (25565) and web (80/443) stay public regardless.
+# allowed_ssh_cidr = "203.0.113.4/32"
+
+# Server sizing — cax31 (ARM, 16 GB) is the recommended default (~EUR 12.49/mo).
+# server_type = "cax31"
+# location    = "fsn1"
+
+# OMCSI secrets (required)
+rcon_password  = "changeme"
+admin_password = "strongpassword"
+
+# Server identity / gameplay
+# operator_uuid = "your-minecraft-uuid"   # from https://mcuuid.net/
+# operator_name = "YourMinecraftName"
+# server_motd   = "An Open Minecraft Server"
+# max_players   = 20
+
+# JVM heap — defaults suit cax31's 16 GB. Lower for smaller types:
+#   cax21 (8 GB):  java_opts = "-Xmx4G -Xms2G"
+# java_opts = "-Xmx6G -Xms4G"
+
+# Container image registry — defaults to "dmccoystephenson" (Docker Hub).
+# The default images are multi-arch (amd64 + arm64), so they run on CAX (ARM).
+# image_registry = "dmccoystephenson"
+
+# Optional: Discord alerts (enables Discord automatically when set)
+# discord_webhook_url = "https://discord.com/api/webhooks/..."
+
+# Optional: plugin hot-deploy bearer token
+# deploy_auth_token = "your-secret-token"
+
+# Optional: agent-manager (Discord AI bot)
+# agent_manager_enabled    = true
+# agent_discord_bot_token  = "BOT_TOKEN"
+# agent_discord_channel_id = "CHANNEL_ID"
+# agent_anthropic_api_key  = "API_KEY"

--- a/terraform/hetzner/values.yaml.tftpl
+++ b/terraform/hetzner/values.yaml.tftpl
@@ -1,0 +1,77 @@
+# =============================================================================
+# OMCSI Helm values for a single-node Hetzner cluster (rendered by Terraform)
+# =============================================================================
+# Uploaded to the server and applied with `helm upgrade --install`. Contains
+# secrets, so it is written with 0600 permissions. Tuned for one self-managed
+# node: services exposed via fixed NodePorts on the node's public IP, the
+# local-path StorageClass for PVCs, and PodDisruptionBudgets disabled (a single
+# node cannot satisfy minAvailable during drains).
+# =============================================================================
+
+minecraftWrapper:
+  image:
+    repository: ${image_registry}/open-mc-server
+  service:
+    type: NodePort
+    minecraftPort: 25565
+    # Served directly on the node IP — requires the widened
+    # service-node-port-range configured by cloud-init.
+    nodePort: ${minecraft_nodeport}
+  env:
+    MINECRAFT_VERSION: "${minecraft_version}"
+    OPERATOR_UUID: "${operator_uuid}"
+    OPERATOR_NAME: "${operator_name}"
+    SERVER_MOTD: "${server_motd}"
+    MAX_PLAYERS: "${max_players}"
+    JAVA_OPTS: "${java_opts}"
+
+webapp:
+  image:
+    repository: ${image_registry}/open-mc-server-webapp
+
+nginx:
+  image:
+    repository: ${image_registry}/open-mc-server-nginx
+  service:
+    type: NodePort
+    httpNodePort: ${http_nodeport}
+    httpsNodePort: ${https_nodeport}
+
+backupManager:
+  image:
+    repository: ${image_registry}/open-mc-server-backup-manager
+
+alertManager:
+  image:
+    repository: ${image_registry}/open-mc-server-alert-manager
+  env:
+    DISCORD_ENABLED: "${discord_enabled}"
+
+agentManager:
+  enabled: ${agent_manager_enabled}
+  image:
+    repository: ${image_registry}/open-mc-server-agent-manager
+
+# Single-node: a PodDisruptionBudget with minAvailable: 1 would block node
+# drains, so disable PDBs here.
+podDisruptionBudgets:
+  enabled: false
+
+persistence:
+  mcserver:
+    storageClass: "${storage_class}"
+  webappData:
+    storageClass: "${storage_class}"
+  alertManagerData:
+    storageClass: "${storage_class}"
+  backups:
+    storageClass: "${storage_class}"
+
+secrets:
+  rconPassword: "${rcon_password}"
+  adminPassword: "${admin_password}"
+  discordWebhookUrl: "${discord_webhook_url}"
+  deployAuthToken: "${deploy_auth_token}"
+  agentDiscordBotToken: "${agent_discord_bot_token}"
+  agentDiscordChannelId: "${agent_discord_channel_id}"
+  agentAnthropicApiKey: "${agent_anthropic_api_key}"

--- a/terraform/hetzner/variables.tf
+++ b/terraform/hetzner/variables.tf
@@ -1,0 +1,231 @@
+# =============================================================================
+# Hetzner Cloud / server variables
+# =============================================================================
+
+variable "hcloud_token" {
+  description = "Hetzner Cloud API token. Provide via -var / tfvars, or export as TF_VAR_hcloud_token. Create one under Project → Security → API Tokens (Read & Write)."
+  type        = string
+  sensitive   = true
+}
+
+variable "server_name" {
+  description = "Name/hostname for the Hetzner Cloud server."
+  type        = string
+  default     = "omcsi"
+}
+
+variable "server_type" {
+  description = "Hetzner Cloud server type. Defaults to cax31 (Ampere ARM64, 8 vCPU / 16 GB / 160 GB NVMe, ~EUR 12.49/mo) which comfortably runs the full OMCSI stack under the $20/mo target. Other ARM options: cax21 (4 vCPU/8 GB), cax41 (16 vCPU/32 GB). For x86 use cpx31. NOTE: ARM types require multi-arch images (the project's CI publishes them)."
+  type        = string
+  default     = "cax31"
+}
+
+variable "location" {
+  description = "Hetzner Cloud location. ARM (CAX) types are available in EU locations: fsn1 (Falkenstein), nbg1 (Nuremberg), hel1 (Helsinki). Use ash/hil for US (x86 only)."
+  type        = string
+  default     = "fsn1"
+}
+
+variable "server_image" {
+  description = "Base OS image. The bootstrap script targets Ubuntu (apt/containerd/kubeadm)."
+  type        = string
+  default     = "ubuntu-24.04"
+}
+
+variable "ssh_public_key" {
+  description = "SSH public key (contents, e.g. the line from ~/.ssh/id_ed25519.pub) added to the server for access."
+  type        = string
+}
+
+variable "ssh_private_key_path" {
+  description = "Path to the matching SSH private key. Terraform uses it to bootstrap and deploy over SSH (provisioners). Not uploaded to the server."
+  type        = string
+}
+
+variable "allowed_ssh_cidr" {
+  description = "CIDR allowed to reach SSH (22) and the Kubernetes API (6443). Defaults to 0.0.0.0/0 for convenience; STRONGLY recommended to restrict to your own IP (e.g. 203.0.113.4/32). The Minecraft (25565) and web (80/443) ports are always open to the internet."
+  type        = string
+  default     = "0.0.0.0/0"
+}
+
+# =============================================================================
+# Kubernetes / cluster bootstrap
+# =============================================================================
+
+variable "kubernetes_version" {
+  description = "Kubernetes minor version to install (matches the pkgs.k8s.io apt channel, e.g. '1.34')."
+  type        = string
+  default     = "1.34"
+}
+
+variable "pod_cidr" {
+  description = "Pod network CIDR for Calico. Keep aligned with Calico's default IP pool (192.168.0.0/16) unless you have a conflict; the bootstrap rewrites the Calico manifest to match."
+  type        = string
+  default     = "192.168.0.0/16"
+}
+
+variable "service_node_port_range" {
+  description = "kube-apiserver --service-node-port-range. Widened from the 30000-32767 default so NodePort Services can bind the standard 25565/80/443 directly on the node's public IP (no cloud LoadBalancer needed)."
+  type        = string
+  default     = "80-32767"
+}
+
+variable "calico_version" {
+  description = "Calico release tag used for the CNI manifests."
+  type        = string
+  default     = "v3.28.2"
+}
+
+variable "local_path_provisioner_version" {
+  description = "Rancher local-path-provisioner release tag, installed as the default StorageClass."
+  type        = string
+  default     = "v0.0.30"
+}
+
+# =============================================================================
+# Public exposure (NodePorts pinned to standard ports on the node IP)
+# =============================================================================
+
+variable "minecraft_node_port" {
+  description = "Fixed NodePort for the Minecraft game port. Must fall within service_node_port_range. Defaults to 25565 so players connect to <server-ip> with no port suffix."
+  type        = number
+  default     = 25565
+}
+
+variable "http_node_port" {
+  description = "Fixed NodePort for the dashboard HTTP port (redirects to HTTPS). Must fall within service_node_port_range."
+  type        = number
+  default     = 80
+}
+
+variable "https_node_port" {
+  description = "Fixed NodePort for the dashboard HTTPS port. Must fall within service_node_port_range."
+  type        = number
+  default     = 443
+}
+
+# =============================================================================
+# OMCSI application configuration
+# =============================================================================
+
+variable "rcon_password" {
+  description = "RCON password for the Minecraft server (required)."
+  type        = string
+  sensitive   = true
+}
+
+variable "admin_password" {
+  description = "Admin password for the OMCSI web dashboard (required)."
+  type        = string
+  sensitive   = true
+}
+
+variable "image_registry" {
+  description = "Container image registry/repository prefix for OMCSI images. Defaults to 'dmccoystephenson' (Docker Hub). Provide only the prefix; images resolve to <prefix>/open-mc-server-*."
+  type        = string
+  default     = "dmccoystephenson"
+
+  validation {
+    condition     = length(regexall("\\s", var.image_registry)) == 0 && !endswith(var.image_registry, "/")
+    error_message = "image_registry must be a registry/repository prefix only, with no whitespace and no trailing '/'."
+  }
+}
+
+variable "storage_class" {
+  description = "StorageClass for PVCs. Defaults to 'local-path' (installed by the bootstrap and marked default)."
+  type        = string
+  default     = "local-path"
+}
+
+variable "helm_release_name" {
+  description = "Helm release name for the OMCSI chart."
+  type        = string
+  default     = "omcsi"
+}
+
+variable "helm_namespace" {
+  description = "Kubernetes namespace for the OMCSI deployment."
+  type        = string
+  default     = "omcsi"
+}
+
+variable "minecraft_version" {
+  description = "Minecraft version tag for the server image."
+  type        = string
+  default     = "26.1"
+}
+
+variable "operator_uuid" {
+  description = "Minecraft UUID of the server operator (op). Leave default to configure ops manually via the console."
+  type        = string
+  default     = "YOUR_UUID_HERE"
+}
+
+variable "operator_name" {
+  description = "Minecraft username of the server operator (op)."
+  type        = string
+  default     = "YOUR_USERNAME_HERE"
+}
+
+variable "server_motd" {
+  description = "Message of the day shown in the Minecraft server list."
+  type        = string
+  default     = "An Open Minecraft Server"
+}
+
+variable "max_players" {
+  description = "Maximum number of concurrent players."
+  type        = number
+  default     = 20
+}
+
+variable "java_opts" {
+  description = "JVM options for the Minecraft server. Defaults size the heap for a 16 GB node (cax31). Reduce for smaller server types (e.g. '-Xmx2G -Xms1G' on cax21)."
+  type        = string
+  default     = "-Xmx6G -Xms4G"
+}
+
+# =============================================================================
+# Optional: notifications, plugin deploy, agent-manager
+# =============================================================================
+
+variable "discord_webhook_url" {
+  description = "Discord webhook URL for alert-manager notifications. When set, Discord alerts are automatically enabled."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "deploy_auth_token" {
+  description = "Bearer token for the plugin hot-deploy endpoint. Leave empty to disable the deploy endpoint."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "agent_manager_enabled" {
+  description = "Enable the agent-manager (Discord AI bot) Deployment."
+  type        = bool
+  default     = false
+}
+
+variable "agent_discord_bot_token" {
+  description = "Discord bot token (required when agent_manager_enabled = true)."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "agent_discord_channel_id" {
+  description = "Discord channel ID (required when agent_manager_enabled = true)."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "agent_anthropic_api_key" {
+  description = "Anthropic API key (required when agent_manager_enabled = true)."
+  type        = string
+  sensitive   = true
+  default     = ""
+}

--- a/terraform/hetzner/versions.tf
+++ b/terraform/hetzner/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    hcloud = {
+      source  = "hetznercloud/hcloud"
+      version = "~> 1.48"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.2"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.5"
+    }
+  }
+}

--- a/web-app/README.md
+++ b/web-app/README.md
@@ -37,15 +37,16 @@ Or use the provided docker-compose which handles this automatically.
 
 The application is configured via environment variables:
 
-- `MC_HOST`: Minecraft server hostname (default: `mcserver`)
+- `MC_HOST`: Minecraft server hostname (default: `minecraft-wrapper` — the wrapper service, not the raw mcserver)
 - `MC_RCON_PORT`: RCON port (default: `25575`)
-- `MC_RCON_PASSWORD`: RCON password (default: `minecraft`)
+- `MC_RCON_PASSWORD`: RCON password (default: `minecraft`). When running via Compose, this is sourced from the top-level `RCON_PASSWORD` in `.env`; see `compose.yml`.
 - `MC_MOTD`: Server MOTD
 - `MC_MAX_PLAYERS`: Maximum players
 - `ADMIN_USERNAME`: Username for admin console (default: `admin`)
 - `ADMIN_PASSWORD`: Password for admin console (default: `admin`)
 - `DYNMAP_URL`: Optional Dynmap URL
 - `BLUEMAP_URL`: Optional BlueMap URL
+- `ACCORDION_CHAT_URL`: Optional Accordion Chat URL (shown as a "Chat" link on the dashboard)
 
 **Security Note**: Change the admin username and password from defaults in production.
 
@@ -55,6 +56,8 @@ Run the application locally:
 
 ```bash
 # Set environment variables
+# (Point MC_HOST at wherever the minecraft-wrapper REST API is reachable;
+# use localhost when running both locally outside Docker.)
 export MC_HOST=localhost
 export MC_RCON_PORT=25575
 export MC_RCON_PASSWORD=minecraft

--- a/web-app/src/main/resources/templates/admin.html
+++ b/web-app/src/main/resources/templates/admin.html
@@ -427,7 +427,7 @@
             </div>
             
             <div id="pluginsListContainer" style="margin-top: 20px;">
-                <div class="empty-state">Click "Refresh List" to load plugins</div>
+                <div class="empty-state">Enter credentials above, then click <strong>Refresh List</strong> to load installed plugins.</div>
             </div>
         </div>
     </div>
@@ -461,6 +461,26 @@
             }
             return creds;
         }
+
+        // Once the user has finished entering both fields, auto-load the plugin
+        // list so they don't have to also click "Refresh List". This removes a
+        // step without changing the underlying authentication model.
+        let pluginsAutoLoaded = false;
+        function maybeAutoLoadPlugins() {
+            if (pluginsAutoLoaded) return;
+            const { username, password } = getCredentials();
+            if (username && password) {
+                pluginsAutoLoaded = true;
+                refreshPlugins();
+            }
+        }
+        document.addEventListener('DOMContentLoaded', () => {
+            const pw = document.getElementById('passwordInput');
+            const un = document.getElementById('usernameInput');
+            // Trigger on the second field losing focus (typical "I'm done entering creds" signal).
+            pw.addEventListener('blur', maybeAutoLoadPlugins);
+            un.addEventListener('blur', maybeAutoLoadPlugins);
+        });
         
         async function sendCommand(event) {
             event.preventDefault();

--- a/web-app/src/main/resources/templates/admin.html
+++ b/web-app/src/main/resources/templates/admin.html
@@ -274,9 +274,60 @@
             text-align: center;
             color: var(--text-faint);
         }
+
+        .field {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            margin-bottom: 12px;
+        }
+
+        .field label {
+            font-weight: 600;
+            font-size: 0.9em;
+            color: var(--text-muted);
+        }
+
+        .toast-region {
+            position: fixed;
+            top: 20px;
+            right: 20px;
+            z-index: 1000;
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+            max-width: 360px;
+        }
+
+        .toast {
+            padding: 12px 16px;
+            border-radius: 8px;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+            color: white;
+            font-weight: 500;
+            animation: toastIn 0.25s ease-out;
+        }
+
+        .toast.success { background: #10b981; }
+        .toast.error { background: #ef4444; }
+        .toast.info { background: #3b82f6; }
+
+        @keyframes toastIn {
+            from { transform: translateX(20px); opacity: 0; }
+            to { transform: translateX(0); opacity: 1; }
+        }
+
+        @media (max-width: 600px) {
+            .toast-region {
+                left: 10px;
+                right: 10px;
+                max-width: none;
+            }
+        }
     </style>
 </head>
 <body>
+    <div id="toastRegion" class="toast-region" role="region" aria-label="Notifications" aria-live="polite"></div>
     <div class="container">
         <div class="header">
             <h1 th:text="'🎮 ' + ${dashboardTitle}">🎮 Minecraft Server Dashboard</h1>
@@ -298,17 +349,23 @@
         <div class="card">
             <h2>Authentication</h2>
             <p style="color: var(--text-muted); margin-bottom: 15px;">Enter your admin credentials to access all admin features</p>
-            <input type="text" 
-                   id="usernameInput" 
-                   class="command-input" 
-                   placeholder="Admin username" 
-                   style="margin-bottom: 10px;"
-                   required>
-            <input type="password" 
-                   id="passwordInput" 
-                   class="command-input" 
-                   placeholder="Admin password" 
-                   required>
+            <div class="field">
+                <label for="usernameInput">Admin username</label>
+                <input type="text"
+                       id="usernameInput"
+                       class="command-input"
+                       autocomplete="username"
+                       placeholder="e.g. admin"
+                       required>
+            </div>
+            <div class="field">
+                <label for="passwordInput">Admin password</label>
+                <input type="password"
+                       id="passwordInput"
+                       class="command-input"
+                       autocomplete="current-password"
+                       required>
+            </div>
         </div>
         
         <!-- Server Commands Card -->
@@ -316,16 +373,19 @@
             <h2>Server Commands</h2>
             <p style="color: var(--text-muted); margin-bottom: 15px;">Send commands to the server using RCON</p>
             <form class="command-form" onsubmit="sendCommand(event)">
-                <div class="command-row">
-                    <input type="text" 
-                           id="commandInput" 
-                           class="command-input" 
-                           placeholder="Enter server command (e.g., list, say Hello)" 
-                           required>
-                    <button type="submit" class="btn btn-primary">Send</button>
+                <div class="field">
+                    <label for="commandInput">Server command</label>
+                    <div class="command-row">
+                        <input type="text"
+                               id="commandInput"
+                               class="command-input"
+                               placeholder="e.g. list, say Hello"
+                               required>
+                        <button type="submit" class="btn btn-primary">Send</button>
+                    </div>
                 </div>
             </form>
-            <div id="commandOutput" class="command-output"></div>
+            <div id="commandOutput" class="command-output" role="log" aria-live="polite"></div>
         </div>
         
         <!-- Server Control Card -->
@@ -378,22 +438,41 @@
             const password = document.getElementById('passwordInput').value.trim();
             return { username, password };
         }
+
+        const toastRegion = document.getElementById('toastRegion');
+        function showToast(message, variant = 'info', durationMs = 4000) {
+            const toast = document.createElement('div');
+            toast.className = `toast ${variant}`;
+            toast.textContent = message;
+            toastRegion.appendChild(toast);
+            setTimeout(() => {
+                toast.style.transition = 'opacity 0.3s ease';
+                toast.style.opacity = '0';
+                setTimeout(() => toast.remove(), 300);
+            }, durationMs);
+        }
+
+        function requireCredentials() {
+            const creds = getCredentials();
+            if (!creds.username || !creds.password) {
+                showToast('Please enter your admin username and password above.', 'error');
+                document.getElementById('usernameInput').focus();
+                return null;
+            }
+            return creds;
+        }
         
         async function sendCommand(event) {
             event.preventDefault();
-            
+
             const commandInput = document.getElementById('commandInput');
             const output = document.getElementById('commandOutput');
-            
-            const { username, password } = getCredentials();
+
+            const creds = requireCredentials();
+            if (!creds) return;
+            const { username, password } = creds;
             const command = commandInput.value.trim();
-            
-            if (!username || !password) {
-                output.textContent = 'Error: Please enter username and password above';
-                output.classList.add('show');
-                return;
-            }
-            
+
             if (!command) return;
             
             output.textContent = 'Sending command...';
@@ -429,13 +508,10 @@
         }
         
         async function refreshPlugins() {
-            const { username, password } = getCredentials();
-            
-            if (!username || !password) {
-                alert('Please enter username and password above');
-                return;
-            }
-            
+            const creds = requireCredentials();
+            if (!creds) return;
+            const { username, password } = creds;
+
             const container = document.getElementById('pluginsListContainer');
             container.innerHTML = '<div class="empty-state">Loading plugins...</div>';
             
@@ -486,58 +562,51 @@
         }
         
         async function uploadPlugin() {
-            const { username, password } = getCredentials();
-            
-            if (!username || !password) {
-                alert('Please enter username and password above');
-                return;
-            }
-            
+            const creds = requireCredentials();
+            if (!creds) return;
+            const { username, password } = creds;
+
             const fileInput = document.getElementById('pluginFileInput');
             if (!fileInput.files.length) {
-                alert('Please select a plugin file');
+                showToast('Please select a plugin file first.', 'error');
                 return;
             }
-            
+
             const formData = new FormData();
             formData.append('username', username);
             formData.append('password', password);
             formData.append('file', fileInput.files[0]);
-            
+
             try {
                 const response = await fetch('/api/plugins/upload', {
                     method: 'POST',
                     body: formData
                 });
-                
+
                 const data = await response.json();
-                
+
                 if (data.success) {
-                    alert(data.message);
+                    showToast(data.message || 'Plugin uploaded.', 'success');
                     fileInput.value = '';
                     document.getElementById('selectedFileName').textContent = '';
                     refreshPlugins();
                 } else {
-                    alert(data.error || data.message);
+                    showToast(data.error || data.message || 'Upload failed.', 'error');
                 }
             } catch (error) {
-                alert('Error uploading plugin: ' + error.message);
+                showToast('Error uploading plugin: ' + error.message, 'error');
             }
         }
         
         async function deletePlugin(filename) {
-            const safeFilename = escapeHtml(String(filename));
-            if (!confirm(`Are you sure you want to delete ${safeFilename}?`)) {
+            if (!confirm(`Delete plugin "${filename}"? This cannot be undone.`)) {
                 return;
             }
-            
-            const { username, password } = getCredentials();
-            
-            if (!username || !password) {
-                alert('Please enter username and password above');
-                return;
-            }
-            
+
+            const creds = requireCredentials();
+            if (!creds) return;
+            const { username, password } = creds;
+
             try {
                 const response = await fetch('/api/plugins/delete', {
                     method: 'POST',
@@ -550,17 +619,17 @@
                         filename: filename
                     })
                 });
-                
+
                 const data = await response.json();
-                
+
                 if (data.success) {
-                    alert(data.message);
+                    showToast(data.message || `Deleted ${filename}.`, 'success');
                     refreshPlugins();
                 } else {
-                    alert(data.error || data.message);
+                    showToast(data.error || data.message || 'Delete failed.', 'error');
                 }
             } catch (error) {
-                alert('Error deleting plugin: ' + error.message);
+                showToast('Error deleting plugin: ' + error.message, 'error');
             }
         }
         
@@ -571,13 +640,10 @@
         }
         
         async function startServer() {
-            const { username, password } = getCredentials();
-            
-            if (!username || !password) {
-                alert('Please enter username and password above');
-                return;
-            }
-            
+            const creds = requireCredentials();
+            if (!creds) return;
+            const { username, password } = creds;
+
             const output = document.getElementById('serverControlOutput');
             output.textContent = 'Starting server...';
             output.classList.add('show');
@@ -602,14 +668,11 @@
         }
         
         async function stopServer() {
-            const { username, password } = getCredentials();
-            
-            if (!username || !password) {
-                alert('Please enter username and password above');
-                return;
-            }
-            
-            if (!confirm('Are you sure you want to stop the server?')) {
+            const creds = requireCredentials();
+            if (!creds) return;
+            const { username, password } = creds;
+
+            if (!confirm('Stop the Minecraft server? Connected players will be disconnected.')) {
                 return;
             }
             
@@ -637,14 +700,11 @@
         }
         
         async function restartServer() {
-            const { username, password } = getCredentials();
-            
-            if (!username || !password) {
-                alert('Please enter username and password above');
-                return;
-            }
-            
-            if (!confirm('Are you sure you want to restart the server?')) {
+            const creds = requireCredentials();
+            if (!creds) return;
+            const { username, password } = creds;
+
+            if (!confirm('Restart the Minecraft server? Connected players will be briefly disconnected.')) {
                 return;
             }
             

--- a/web-app/src/main/resources/templates/admin.html
+++ b/web-app/src/main/resources/templates/admin.html
@@ -324,9 +324,47 @@
                 max-width: none;
             }
         }
+
+        .skip-link {
+            position: absolute;
+            top: -40px;
+            left: 8px;
+            background: var(--card-bg);
+            color: var(--primary-color);
+            padding: 8px 16px;
+            border-radius: 6px;
+            text-decoration: none;
+            font-weight: 600;
+            z-index: 1100;
+            transition: top 0.2s ease;
+        }
+        .skip-link:focus {
+            top: 8px;
+            outline: 3px solid var(--primary-color);
+            outline-offset: 2px;
+        }
+
+        /* Visible focus rings everywhere — the global `outline: none` on inputs
+           is fine since we add a border-color focus state, but buttons and nav
+           links also need a visible focus indicator for keyboard users. */
+        .btn:focus-visible,
+        .nav a:focus-visible,
+        .btn-danger:focus-visible,
+        .file-input-label:focus-within {
+            outline: 3px solid #fbbf24;
+            outline-offset: 2px;
+        }
+
+        .btn[aria-busy="true"],
+        .btn-danger[aria-busy="true"] {
+            opacity: 0.7;
+            cursor: progress;
+            pointer-events: none;
+        }
     </style>
 </head>
 <body>
+    <a href="#mainContent" class="skip-link">Skip to main content</a>
     <div id="toastRegion" class="toast-region" role="region" aria-label="Notifications" aria-live="polite"></div>
     <div class="container">
         <div class="header">
@@ -345,6 +383,7 @@
             </a>
         </div>
         
+        <main id="mainContent">
         <!-- Credentials Card -->
         <div class="card">
             <h2>Authentication</h2>
@@ -393,17 +432,23 @@
             <h2>Server Control</h2>
             <p style="color: var(--text-muted); margin-bottom: 15px;">Start, stop, or restart the Minecraft server</p>
             <div style="display: flex; gap: 10px; flex-wrap: wrap;">
-                <button onclick="startServer()" class="btn btn-primary" style="background: #10b981;">
+                <button type="button" id="btnStartServer" onclick="startServer()"
+                        class="btn btn-primary" style="background: #10b981;"
+                        aria-label="Start the Minecraft server">
                     ▶ Start Server
                 </button>
-                <button onclick="stopServer()" class="btn btn-primary" style="background: #ef4444;">
+                <button type="button" id="btnStopServer" onclick="stopServer()"
+                        class="btn btn-primary" style="background: #ef4444;"
+                        aria-label="Stop the Minecraft server (disconnects players)">
                     ⏹ Stop Server
                 </button>
-                <button onclick="restartServer()" class="btn btn-primary" style="background: #f59e0b;">
+                <button type="button" id="btnRestartServer" onclick="restartServer()"
+                        class="btn btn-primary" style="background: #f59e0b;"
+                        aria-label="Restart the Minecraft server (briefly disconnects players)">
                     🔄 Restart Server
                 </button>
             </div>
-            <div id="serverControlOutput" class="command-output"></div>
+            <div id="serverControlOutput" class="command-output" role="status" aria-live="polite"></div>
         </div>
         
         <!-- Plugin Management Card -->
@@ -430,8 +475,9 @@
                 <div class="empty-state">Enter credentials above, then click <strong>Refresh List</strong> to load installed plugins.</div>
             </div>
         </div>
+        </main>
     </div>
-    
+
     <script>
         function getCredentials() {
             const username = document.getElementById('usernameInput').value.trim();
@@ -659,15 +705,32 @@
             return div.innerHTML;
         }
         
+        // Lock all server-control buttons while any one is in flight so a user
+        // can't click Stop and Restart concurrently and confuse the wrapper.
+        function setServerControlsBusy(busy) {
+            ['btnStartServer', 'btnStopServer', 'btnRestartServer'].forEach(id => {
+                const el = document.getElementById(id);
+                if (!el) return;
+                if (busy) {
+                    el.setAttribute('aria-busy', 'true');
+                    el.disabled = true;
+                } else {
+                    el.removeAttribute('aria-busy');
+                    el.disabled = false;
+                }
+            });
+        }
+
         async function startServer() {
             const creds = requireCredentials();
             if (!creds) return;
             const { username, password } = creds;
 
             const output = document.getElementById('serverControlOutput');
-            output.textContent = 'Starting server...';
+            output.textContent = 'Starting server…';
             output.classList.add('show');
-            
+            setServerControlsBusy(true);
+
             try {
                 const response = await fetch('/api/server/start', {
                     method: 'POST',
@@ -679,11 +742,13 @@
                         password: password
                     })
                 });
-                
+
                 const data = await response.json();
                 output.textContent = data.success ? '✓ ' + data.message : '✗ ' + data.message;
             } catch (error) {
                 output.textContent = '✗ Error: ' + error.message;
+            } finally {
+                setServerControlsBusy(false);
             }
         }
         
@@ -695,11 +760,12 @@
             if (!confirm('Stop the Minecraft server? Connected players will be disconnected.')) {
                 return;
             }
-            
+
             const output = document.getElementById('serverControlOutput');
-            output.textContent = 'Stopping server...';
+            output.textContent = 'Stopping server…';
             output.classList.add('show');
-            
+            setServerControlsBusy(true);
+
             try {
                 const response = await fetch('/api/server/stop', {
                     method: 'POST',
@@ -711,11 +777,13 @@
                         password: password
                     })
                 });
-                
+
                 const data = await response.json();
                 output.textContent = data.success ? '✓ ' + data.message : '✗ ' + data.message;
             } catch (error) {
                 output.textContent = '✗ Error: ' + error.message;
+            } finally {
+                setServerControlsBusy(false);
             }
         }
         
@@ -727,11 +795,12 @@
             if (!confirm('Restart the Minecraft server? Connected players will be briefly disconnected.')) {
                 return;
             }
-            
+
             const output = document.getElementById('serverControlOutput');
-            output.textContent = 'Restarting server...';
+            output.textContent = 'Restarting server…';
             output.classList.add('show');
-            
+            setServerControlsBusy(true);
+
             try {
                 const response = await fetch('/api/server/restart', {
                     method: 'POST',
@@ -743,11 +812,13 @@
                         password: password
                     })
                 });
-                
+
                 const data = await response.json();
                 output.textContent = data.success ? '✓ ' + data.message : '✗ ' + data.message;
             } catch (error) {
                 output.textContent = '✗ Error: ' + error.message;
+            } finally {
+                setServerControlsBusy(false);
             }
         }
     </script>

--- a/web-app/src/main/resources/templates/index.html
+++ b/web-app/src/main/resources/templates/index.html
@@ -167,12 +167,35 @@
         
         .command-form {
             display: flex;
-            gap: 10px;
+            flex-direction: column;
+            gap: 12px;
             margin-top: 15px;
         }
-        
-        .command-input {
+
+        .field {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+        }
+
+        .field label {
+            font-weight: 600;
+            font-size: 0.9em;
+            color: var(--text-muted);
+        }
+
+        .command-row {
+            display: flex;
+            gap: 10px;
+            align-items: flex-end;
+        }
+
+        .command-row .field {
             flex: 1;
+        }
+
+        .command-input {
+            width: 100%;
             padding: 12px;
             border: 2px solid var(--input-border);
             border-radius: 8px;
@@ -208,6 +231,34 @@
             color: var(--text-faint);
             font-style: italic;
         }
+
+        .refresh-status {
+            text-align: center;
+            color: rgba(255,255,255,0.85);
+            font-size: 0.85em;
+            margin-bottom: 15px;
+        }
+
+        .refresh-status .refresh-dot {
+            display: inline-block;
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            background: rgba(255,255,255,0.7);
+            margin-right: 6px;
+            vertical-align: middle;
+            transition: background 0.3s ease;
+        }
+
+        .refresh-status.refreshing .refresh-dot {
+            background: #fde68a;
+            animation: pulse 1s ease-in-out infinite;
+        }
+
+        @keyframes pulse {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0.4; }
+        }
     </style>
 </head>
 <body>
@@ -216,27 +267,32 @@
             <h1>🎮 Minecraft Server Dashboard</h1>
             <p>Server Management & Information</p>
         </div>
-        
+
+        <div id="refreshStatus" class="refresh-status" role="status" aria-live="polite">
+            <span class="refresh-dot" aria-hidden="true"></span>
+            <span id="refreshStatusText">Status updates automatically</span>
+        </div>
+
         <div class="card">
             <h2>Server Status</h2>
             <div class="info-row">
                 <span class="info-label">Status</span>
                 <span class="info-value">
-                    <span th:class="${status.online} ? 'status-indicator status-online' : 'status-indicator status-offline'"></span>
-                    <span th:text="${status.online} ? 'Online' : 'Offline'">Online</span>
+                    <span id="statusIndicator" th:class="${status.online} ? 'status-indicator status-online' : 'status-indicator status-offline'"></span>
+                    <span id="statusText" th:text="${status.online} ? 'Online' : 'Offline'">Online</span>
                 </span>
             </div>
             <div class="info-row">
                 <span class="info-label">MOTD</span>
-                <span class="info-value" th:text="${status.motd}">A Private Minecraft Server</span>
+                <span class="info-value" id="motdValue" th:text="${status.motd}">A Private Minecraft Server</span>
             </div>
             <div class="info-row">
                 <span class="info-label">Max Players</span>
-                <span class="info-value" th:text="${status.maxPlayers}">20</span>
+                <span class="info-value" id="maxPlayersValue" th:text="${status.maxPlayers}">20</span>
             </div>
             <div class="info-row">
                 <span class="info-label">Current Players</span>
-                <span class="info-value" th:text="${status.playerList}">Loading...</span>
+                <span class="info-value" id="playerListValue" th:text="${status.playerList}">Loading...</span>
             </div>
         </div>
         
@@ -282,26 +338,40 @@
             <h2>Admin Console</h2>
             <p style="color: var(--text-muted); margin-bottom: 15px;">Send commands to the server using RCON</p>
             <form class="command-form" onsubmit="sendCommand(event)">
-                <input type="text" 
-                       id="usernameInput" 
-                       class="command-input" 
-                       placeholder="Admin username" 
-                       required
-                       style="margin-bottom: 10px;">
-                <input type="password" 
-                       id="passwordInput" 
-                       class="command-input" 
-                       placeholder="Admin password" 
-                       required
-                       style="margin-bottom: 10px;">
-                <input type="text" 
-                       id="commandInput" 
-                       class="command-input" 
-                       placeholder="Enter server command (e.g., list, say Hello)" 
-                       required>
-                <button type="submit" class="btn btn-primary">Send</button>
+                <div class="command-row">
+                    <div class="field">
+                        <label for="usernameInput">Admin username</label>
+                        <input type="text"
+                               id="usernameInput"
+                               class="command-input"
+                               autocomplete="username"
+                               placeholder="e.g. admin"
+                               required>
+                    </div>
+                    <div class="field">
+                        <label for="passwordInput">Admin password</label>
+                        <input type="password"
+                               id="passwordInput"
+                               class="command-input"
+                               autocomplete="current-password"
+                               required>
+                    </div>
+                </div>
+                <div class="field">
+                    <label for="commandInput">Server command</label>
+                    <div class="command-row">
+                        <div class="field" style="gap: 0;">
+                            <input type="text"
+                                   id="commandInput"
+                                   class="command-input"
+                                   placeholder="e.g. list, say Hello"
+                                   required>
+                        </div>
+                        <button type="submit" class="btn btn-primary">Send</button>
+                    </div>
+                </div>
             </form>
-            <div id="commandOutput" class="command-output"></div>
+            <div id="commandOutput" class="command-output" role="log" aria-live="polite"></div>
         </div>
     </div>
     
@@ -343,17 +413,51 @@
             }
         }
         
-        // Auto-refresh status
+        // Auto-refresh status — partial DOM update so user input is preserved
         const refreshInterval = /*[[${refreshIntervalMs}]]*/ 1800000;
-        setInterval(async () => {
+        const refreshStatusEl = document.getElementById('refreshStatus');
+        const refreshStatusTextEl = document.getElementById('refreshStatusText');
+
+        function formatNextRefresh(ms) {
+            const totalSeconds = Math.round(ms / 1000);
+            if (totalSeconds < 60) return `${totalSeconds}s`;
+            const minutes = Math.floor(totalSeconds / 60);
+            const seconds = totalSeconds % 60;
+            return seconds === 0 ? `${minutes} min` : `${minutes} min ${seconds}s`;
+        }
+
+        function setRefreshStatus(text, refreshing) {
+            refreshStatusTextEl.textContent = text;
+            refreshStatusEl.classList.toggle('refreshing', !!refreshing);
+        }
+
+        async function refreshStatus() {
+            setRefreshStatus('Refreshing…', true);
             try {
                 const response = await fetch('/api/status');
+                if (!response.ok) throw new Error('HTTP ' + response.status);
                 const status = await response.json();
-                location.reload();
+
+                const indicator = document.getElementById('statusIndicator');
+                const statusText = document.getElementById('statusText');
+                indicator.className = status.online
+                    ? 'status-indicator status-online'
+                    : 'status-indicator status-offline';
+                statusText.textContent = status.online ? 'Online' : 'Offline';
+
+                if (status.motd != null) document.getElementById('motdValue').textContent = status.motd;
+                if (status.maxPlayers != null) document.getElementById('maxPlayersValue').textContent = status.maxPlayers;
+                if (status.playerList != null) document.getElementById('playerListValue').textContent = status.playerList;
+
+                setRefreshStatus(`Updated just now · next in ${formatNextRefresh(refreshInterval)}`, false);
             } catch (error) {
                 console.error('Failed to refresh status:', error);
+                setRefreshStatus('Update failed — will retry', false);
             }
-        }, refreshInterval);
+        }
+
+        setRefreshStatus(`Auto-refreshes every ${formatNextRefresh(refreshInterval)}`, false);
+        setInterval(refreshStatus, refreshInterval);
     </script>
 </body>
 </html>

--- a/web-app/src/main/resources/templates/player.html
+++ b/web-app/src/main/resources/templates/player.html
@@ -271,14 +271,22 @@
         
         <div class="card" th:if="${profile == null}">
             <div class="error-message">
-                <div class="error-icon">❌</div>
-                <div th:text="${error}">Player not found</div>
-                <p style="margin-top: 10px; font-size: 0.9em; color: var(--text-muted);">
-                    This player may not have any recorded activity yet.
+                <div class="error-icon" aria-hidden="true">❌</div>
+                <h2 style="border-bottom: none; padding-bottom: 0; color: var(--text-primary); margin-bottom: 10px;">
+                    Player not found
+                </h2>
+                <p th:if="${playerName != null}" style="color: var(--text-secondary); font-size: 1em; margin-bottom: 8px;">
+                    We couldn't find a player named
+                    <strong style="font-family: 'Courier New', monospace;" th:text="${playerName}">PlayerName</strong>.
+                </p>
+                <p style="margin-top: 6px; font-size: 0.9em; color: var(--text-muted);">
+                    Players appear here once they've logged into the server at least once with activity tracking enabled.
+                    Double-check the spelling — names are case-sensitive.
                 </p>
             </div>
             <div class="nav-buttons">
-                <a href="/public" class="btn btn-primary">← Back to Dashboard</a>
+                <a href="/public" class="btn btn-primary">← Back to dashboard</a>
+                <a href="/public#leaderboard" class="btn btn-secondary">View leaderboard</a>
             </div>
         </div>
     </div>

--- a/web-app/src/main/resources/templates/public.html
+++ b/web-app/src/main/resources/templates/public.html
@@ -75,28 +75,50 @@
                     "header header header"
                     "left-sidebar main right-sidebar";
             }
-            
+
             .header-section {
                 grid-area: header;
             }
-            
+
             .left-sidebar {
                 grid-area: left-sidebar;
             }
-            
+
             .main-content {
                 grid-area: main;
             }
-            
+
             .right-sidebar {
                 grid-area: right-sidebar;
             }
         }
-        
+
         @media (max-width: 1023px) {
-            .left-sidebar,
+            /* On small screens: keep header first, then put quick-stats/quick-links
+               above the main content (instead of hiding them entirely as before).
+               Hide the lower-priority Recent Activity sidebar to keep scroll
+               length reasonable. */
+            .header-section { order: 0; }
+            .left-sidebar { order: 1; }
+            .main-content { order: 2; }
             .right-sidebar {
                 display: none;
+            }
+
+            .left-sidebar {
+                display: grid;
+                grid-template-columns: 1fr;
+                gap: 15px;
+            }
+        }
+
+        @media (min-width: 600px) and (max-width: 1023px) {
+            /* Show the two sidebar cards side-by-side on tablet/landscape phones */
+            .left-sidebar {
+                grid-template-columns: 1fr 1fr;
+            }
+            .left-sidebar .sidebar-card {
+                margin-bottom: 0;
             }
         }
         
@@ -732,7 +754,7 @@
             </div>
         </div>
         
-        <div th:if="${activityTrackerEnabled}" class="card">
+        <div th:if="${activityTrackerEnabled}" class="card" id="leaderboard">
             <h2>🏆 Player Leaderboard</h2>
             <p style="color: var(--text-muted); margin-bottom: 15px;">Top 10 players by hours played</p>
             <div id="leaderboardTable">
@@ -745,10 +767,15 @@
             <p style="color: var(--text-muted); margin-bottom: 15px;">Historical server metrics</p>
             
             <div class="history-size-control">
-                <label for="historySizeSlider">History Size:</label>
-                <input type="range" id="historySizeSlider" min="5" max="50" value="10" step="1">
+                <label for="historySizeSlider">History size:</label>
+                <input type="range" id="historySizeSlider" min="5" max="50" value="10" step="1"
+                       aria-describedby="historySizeInfo">
                 <span class="history-size-value" id="historySizeValue">10</span>
-                <div class="history-size-info">Adjust to view more historical data points (session only)</div>
+                <span style="color: var(--text-muted); font-size: 14px;">points</span>
+                <div class="history-size-info" id="historySizeInfo">
+                    Each point is one status check (every <span id="historySizeIntervalText">…</span>).
+                    <span id="historySizeWindowText"></span>
+                </div>
             </div>
             
             <div style="margin-bottom: 30px;">
@@ -815,6 +842,9 @@
     </div>
     
     <script th:inline="javascript">
+        // Refresh interval (ms) is also used by the history-size hint, so hoist it.
+        const refreshInterval = /*[[${refreshIntervalMs}]]*/ 1800000;
+
         // Utility function to convert timestamp to relative time
         function getRelativeTime(timestamp) {
             if (!timestamp) return 'N/A';
@@ -1268,6 +1298,25 @@
         const historySizeSlider = document.getElementById('historySizeSlider');
         const historySizeValue = document.getElementById('historySizeValue');
         
+        function formatDuration(ms) {
+            const totalSeconds = Math.round(ms / 1000);
+            if (totalSeconds < 60) return `${totalSeconds} sec`;
+            const minutes = Math.floor(totalSeconds / 60);
+            const seconds = totalSeconds % 60;
+            if (minutes < 60) return seconds === 0 ? `${minutes} min` : `${minutes} min ${seconds} sec`;
+            const hours = Math.floor(minutes / 60);
+            const remMin = minutes % 60;
+            return remMin === 0 ? `${hours} hr` : `${hours} hr ${remMin} min`;
+        }
+
+        function updateHistorySizeHints(size) {
+            const intervalEl = document.getElementById('historySizeIntervalText');
+            const windowEl = document.getElementById('historySizeWindowText');
+            if (intervalEl) intervalEl.textContent = formatDuration(refreshInterval);
+            if (windowEl) windowEl.textContent =
+                `Covers about ${formatDuration(refreshInterval * size)} of history (session only).`;
+        }
+
         if (historySizeSlider && historySizeValue) {
             // Fetch current max size on load
             fetch('/api/history/max-size')
@@ -1276,14 +1325,16 @@
                     const currentSize = data.maxSize || 10;
                     historySizeSlider.value = currentSize;
                     historySizeValue.textContent = currentSize;
+                    updateHistorySizeHints(currentSize);
                 })
                 .catch(error => console.error('Failed to fetch current history size:', error));
-            
+
             // Update display value as slider moves
             historySizeSlider.addEventListener('input', (e) => {
                 historySizeValue.textContent = e.target.value;
+                updateHistorySizeHints(parseInt(e.target.value, 10));
             });
-            
+
             // Update backend when slider is released
             historySizeSlider.addEventListener('change', (e) => {
                 const newSize = parseInt(e.target.value, 10);
@@ -1362,8 +1413,8 @@
             loadActivityTrackerLeaderboard();
         }
         
-        // Auto-refresh status — partial DOM update so user state is preserved
-        const refreshInterval = /*[[${refreshIntervalMs}]]*/ 1800000;
+        // Auto-refresh status — partial DOM update so user state is preserved.
+        // refreshInterval is declared at the top of the script.
 
         async function refreshStatus() {
             try {

--- a/web-app/src/main/resources/templates/public.html
+++ b/web-app/src/main/resources/templates/public.html
@@ -572,8 +572,8 @@
                 <div class="quick-stat">
                     <span class="quick-stat-label">Status</span>
                     <span class="quick-stat-value" id="sidebar-status">
-                        <span th:class="${status.online} ? 'status-indicator status-online' : 'status-indicator status-offline'"></span>
-                        <span th:text="${status.online} ? 'Online' : 'Offline'">Online</span>
+                        <span data-status-online th:class="${status.online} ? 'status-indicator status-online' : 'status-indicator status-offline'"></span>
+                        <span data-status-text th:text="${status.online} ? 'Online' : 'Offline'">Online</span>
                     </span>
                 </div>
                 <div class="quick-stat">
@@ -631,8 +631,8 @@
             <div class="info-row">
                 <span class="info-label">Status</span>
                 <span class="info-value">
-                    <span th:class="${status.online} ? 'status-indicator status-online' : 'status-indicator status-offline'"></span>
-                    <span th:text="${status.online} ? 'Online' : 'Offline'">Online</span>
+                    <span data-status-online th:class="${status.online} ? 'status-indicator status-online' : 'status-indicator status-offline'"></span>
+                    <span data-status-text th:text="${status.online} ? 'Online' : 'Offline'">Online</span>
                 </span>
             </div>
             <div class="info-row">
@@ -1362,21 +1362,39 @@
             loadActivityTrackerLeaderboard();
         }
         
-        // Auto-refresh status
+        // Auto-refresh status — partial DOM update so user state is preserved
         const refreshInterval = /*[[${refreshIntervalMs}]]*/ 1800000;
-        setInterval(async () => {
+
+        async function refreshStatus() {
             try {
                 const response = await fetch('/api/status');
+                if (!response.ok) throw new Error('HTTP ' + response.status);
                 const status = await response.json();
-                loadHistory(); // Refresh history chart
-                if (activityTrackerEnabled) {
-                    loadActivityTrackerStats();
-                    loadActivityTrackerLeaderboard();
-                }
-                location.reload();
+
+                document.querySelectorAll('[data-status-online]').forEach(el => {
+                    el.className = status.online
+                        ? 'status-indicator status-online'
+                        : 'status-indicator status-offline';
+                });
+                document.querySelectorAll('[data-status-text]').forEach(el => {
+                    el.textContent = status.online ? 'Online' : 'Offline';
+                });
+
+                // Update Last Updated relative timestamp (server-rendered value remains; recompute relative)
+                updateRelativeTime();
             } catch (error) {
                 console.error('Failed to refresh status:', error);
             }
+        }
+
+        setInterval(() => {
+            refreshStatus();
+            loadHistory();
+            if (activityTrackerEnabled) {
+                loadActivityTrackerStats();
+                loadActivityTrackerLeaderboard();
+            }
+            loadDeploymentHistory();
         }, refreshInterval);
     </script>
 </body>

--- a/web-app/src/main/resources/templates/public.html
+++ b/web-app/src/main/resources/templates/public.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title th:text="${dashboardTitle}">Minecraft Server Dashboard</title>
+    <title th:text="${dashboardTitle} + ' — Dashboard'">Minecraft Server Dashboard — Dashboard</title>
     <style>
         :root {
             --primary-color: /*[[${dashboardPrimaryColor}]]*/ #667eea;
@@ -570,9 +570,44 @@
             text-align: center;
             color: var(--text-faint);
         }
+
+        .skip-link {
+            position: absolute;
+            top: -40px;
+            left: 8px;
+            background: var(--card-bg);
+            color: var(--primary-color);
+            padding: 8px 16px;
+            border-radius: 6px;
+            text-decoration: none;
+            font-weight: 600;
+            z-index: 1100;
+            transition: top 0.2s ease;
+        }
+        .skip-link:focus {
+            top: 8px;
+            outline: 3px solid var(--primary-color);
+            outline-offset: 2px;
+        }
+
+        .btn:focus-visible,
+        .nav a:focus-visible {
+            outline: 3px solid #fbbf24;
+            outline-offset: 2px;
+        }
+
+        /* Visually-hidden text for screen-readers only (used for chart summaries). */
+        .visually-hidden {
+            position: absolute;
+            width: 1px; height: 1px;
+            padding: 0; margin: -1px;
+            overflow: hidden; clip: rect(0,0,0,0);
+            white-space: nowrap; border: 0;
+        }
     </style>
 </head>
 <body>
+    <a href="#mainContent" class="skip-link">Skip to main content</a>
     <div class="dashboard-grid">
         <!-- Header Section -->
         <div class="header-section">
@@ -646,7 +681,7 @@
         </aside>
         
         <!-- Main Content -->
-        <main class="main-content">
+        <main class="main-content" id="mainContent">
         
         <div class="card">
             <h2>Server Status</h2>
@@ -779,39 +814,48 @@
             </div>
             
             <div style="margin-bottom: 30px;">
-                <h3 class="chart-section-title">Player Activity Over Time</h3>
+                <h3 class="chart-section-title" id="playerChartTitle">Player Activity Over Time</h3>
                 <div class="chart-container">
-                    <canvas id="playerChart" class="chart-canvas"></canvas>
+                    <canvas id="playerChart" class="chart-canvas"
+                            role="img" aria-labelledby="playerChartTitle"
+                            aria-describedby="playerChartSummary"></canvas>
                 </div>
+                <div id="playerChartSummary" class="visually-hidden" aria-live="polite">Chart loading…</div>
                 <div class="chart-legend">
                     <div class="chart-legend-item">
-                        <div class="chart-legend-color" style="background: #22c55e;"></div>
+                        <div class="chart-legend-color" style="background: #22c55e;" aria-hidden="true"></div>
                         <span>Players Online</span>
                     </div>
                 </div>
             </div>
-            
+
             <div>
-                <h3 class="chart-section-title">Memory Usage Over Time</h3>
+                <h3 class="chart-section-title" id="memoryChartTitle">Memory Usage Over Time</h3>
                 <div class="chart-container">
-                    <canvas id="memoryChart" class="chart-canvas"></canvas>
+                    <canvas id="memoryChart" class="chart-canvas"
+                            role="img" aria-labelledby="memoryChartTitle"
+                            aria-describedby="memoryChartSummary"></canvas>
                 </div>
+                <div id="memoryChartSummary" class="visually-hidden" aria-live="polite">Chart loading…</div>
                 <div class="chart-legend">
                     <div class="chart-legend-item">
-                        <div class="chart-legend-color" style="background: #3b82f6;"></div>
+                        <div class="chart-legend-color" style="background: #3b82f6;" aria-hidden="true"></div>
                         <span>Memory Usage %</span>
                     </div>
                 </div>
             </div>
-            
+
             <div style="margin-top: 30px;">
-                <h3 class="chart-section-title">TPS (Ticks Per Second) Over Time</h3>
+                <h3 class="chart-section-title" id="tpsChartTitle">TPS (Ticks Per Second) Over Time</h3>
                 <div class="chart-container">
-                    <canvas id="tpsChart" class="chart-canvas"></canvas>
+                    <canvas id="tpsChart" class="chart-canvas"
+                            role="img" aria-labelledby="tpsChartTitle"
+                            aria-describedby="tpsChartSummary"></canvas>
                 </div>
+                <div id="tpsChartSummary" class="visually-hidden" aria-live="polite">Chart loading…</div>
                 <div class="chart-legend">
                     <div class="chart-legend-item">
-                        <div class="chart-legend-color" style="background: #f59e0b;"></div>
+                        <div class="chart-legend-color" style="background: #f59e0b;" aria-hidden="true"></div>
                         <span>TPS</span>
                     </div>
                 </div>
@@ -1078,7 +1122,26 @@
                     yMin: 0,
                     yMax: 20
                 });
-                
+
+                // Accessible summaries — screen readers can't read a canvas.
+                function summarize(label, points, unit, decimals) {
+                    if (!points.length) return `${label}: no data available.`;
+                    const values = points.map(p => p.value);
+                    const min = Math.min(...values);
+                    const max = Math.max(...values);
+                    const latest = values[values.length - 1];
+                    const fmt = (n) => decimals != null ? n.toFixed(decimals) : Math.round(n);
+                    return `${label} over the last ${points.length} samples: ` +
+                        `latest ${fmt(latest)}${unit}, ` +
+                        `min ${fmt(min)}${unit}, max ${fmt(max)}${unit}.`;
+                }
+                const playerSummaryEl = document.getElementById('playerChartSummary');
+                const memorySummaryEl = document.getElementById('memoryChartSummary');
+                const tpsSummaryEl = document.getElementById('tpsChartSummary');
+                if (playerSummaryEl) playerSummaryEl.textContent = summarize('Players online', playerData, '', 0);
+                if (memorySummaryEl) memorySummaryEl.textContent = summarize('Memory usage', memoryData, '%', 1);
+                if (tpsSummaryEl) tpsSummaryEl.textContent = summarize('TPS', tpsData, '', 1);
+
                 // Update recent activity sidebar
                 updateRecentActivity(reversedHistory);
                 


### PR DESCRIPTION
## Why

The project's stated goal is accessible, **cost-effective** hosting, but the only cloud paths were managed Kubernetes. Their cost is dominated by *infrastructure tax* the workload never needed — a control-plane fee, a cloud LoadBalancer, a NAT gateway, and oversized nodes — even though OMCSI's real real footprint is ~5 GB of RAM (one Minecraft server + a few small Spring services):

| Target | Est. monthly |
|---|---|
| EKS (managed) | ~$248 |
| LKE (managed) | ~$109 |
| **Hetzner CAX31 (this PR)** | **~$14** |

A self-managed single-node path was added that removes those line items and lands under the $20/month target.

## What changed

- **`terraform/hetzner/`** — provisions one Hetzner Cloud server (`cax31` ARM by default), bootstraps a single-node Kubernetes cluster on it with `kubeadm` via cloud-init, and deploys the shared OMCSI Helm chart. The cost-killers, all CKA-style:
  - control plane runs on the node (untainted) — **no control-plane fee**
  - services exposed via fixed NodePorts (25565/80/443) on the node's public IP, with the API server's `--service-node-port-range` widened to `80-32767` — **no cloud LoadBalancer**
  - public IP on the node — **no NAT gateway**
  - Rancher `local-path` provisioner as the default StorageClass — **no separate block storage**
  - Calico CNI so the chart's NetworkPolicies are enforced; PodDisruptionBudgets disabled (single node)
  - the chart is deployed over SSH from the node, because a freshly bootstrapped kubeadm node exposes no API credentials as Terraform attributes at plan time (documented in `main.tf` and `CLAUDE.md`)
- **Helm chart** — optional, backward-compatible `nodePort` fields were added to the `minecraft-wrapper` and `nginx` Services so a single public IP can serve the standard ports. Defaults are unchanged; covered by helm unittests (`tests/nginx_test.yaml`, additions to `tests/minecraft_wrapper_test.yaml`).
- **CI** — images are now published multi-arch (`linux/amd64,linux/arm64`) so ARM hosts (Hetzner CAX, Oracle Ampere) run the default images. QEMU was added; a note recommends native ARM runners for speed since the Spigot image builds from source.
- **Docs** — a README Hetzner section, a self-managed tier in `terraform/COST_ANALYSIS.md`, and a `CLAUDE.md` entry.

## Verification

**Verified against live infrastructure on 2026-06-07.**

`terraform apply` was run end-to-end from a clean Hetzner account (no prior infrastructure). A `cx43` server (8 vCPU / 16 GB x86, EUR 13.99/mo) in `nbg1` was used — the default `cax31` ARM64 type was sold out across all three EU locations at time of deploy; `cx43` is a direct spec/price equivalent and confirmed working. The module is not ARM-specific.

Results:
- Server provisioned and kubeadm cluster bootstrapped successfully via cloud-init
- Helm chart deployed (`STATUS: deployed`, `REVISION: 1`) ~3.5 minutes after bootstrap completed
- All 5 pods reached `Running` within ~4 minutes of apply completing: `alert-manager`, `backup-manager`, `minecraft-wrapper`, `nginx`, `webapp`
- Dashboard confirmed accessible over HTTPS on the node's public IP (self-signed cert as documented)
- Minecraft port (25565) live after Spigot's first-boot BuildTools compile (~10–15 min)
- All `terraform output` values (`minecraft_address`, `dashboard_url`, `server_ipv4`, `ssh_command`, `kubeconfig_path`) populated correctly
- Kubeconfig written to `terraform/hetzner/kubeconfig.yaml` with API server address rewritten to node's public IP

> **Note on server type availability:** `cax31` ARM64 was sold out at all EU locations at time of first deploy. `cx43` x86 works as a drop-in. If `cax31` is available when you deploy, it is expected to work identically given the multi-arch images.

Previously verified by static analysis: `helm lint`, `helm template` (22 objects, NodePorts pinned, no PDBs, `local-path` PVCs), `terraform validate`, `terraform fmt`, `docker compose config`.

## Notes / trade-offs

- Self-managed means you own cluster operations (upgrades, etcd backups, node maintenance) and there is no HA — the explicit deal for the lower price.
- `allowed_ssh_cidr` defaults to `0.0.0.0/0` for first-run convenience but should be restricted; game/web ports are public by design.
- `terraform destroy` deletes the node and all world data on it — back up first.

---

*This pull request was drafted by Claude on behalf of Daniel Stephenson.*