### PR TITLE
fix: route /api/plugins/ through nginx to minecraft-wrapper

### DIFF
--- a/helm/omcsi/templates/networkpolicies.yaml
+++ b/helm/omcsi/templates/networkpolicies.yaml
@@ -45,6 +45,9 @@ spec:
         - podSelector:
             matchLabels:
               {{- include "omcsi.selectorLabels" (dict "root" . "component" "agent-manager") | nindent 14 }}
+        - podSelector:
+            matchLabels:
+              {{- include "omcsi.selectorLabels" (dict "root" . "component" "nginx") | nindent 14 }}
         - ipBlock:
             cidr: {{ ((.Values.networkPolicy).kubeNodeCIDR) | default "0.0.0.0/0" | quote }}
     # Prometheus scrape of wrapper actuator metrics (cross-namespace)
@@ -214,6 +217,14 @@ spec:
         - podSelector:
             matchLabels:
               {{- include "omcsi.selectorLabels" (dict "root" . "component" "webapp") | nindent 14 }}
+    # minecraft-wrapper plugin deploy endpoint
+    - ports:
+        - port: {{ .Values.minecraftWrapper.internalService.wrapperPort }}
+          protocol: TCP
+      to:
+        - podSelector:
+            matchLabels:
+              {{- include "omcsi.selectorLabels" (dict "root" . "component" "minecraft-wrapper") | nindent 14 }}
     # DNS — scoped to CoreDNS (adjust networkPolicy.dnsNamespaceSelector/dnsPodSelector for non-standard distros)
     - ports:
         - port: 53

--- a/helm/omcsi/templates/nginx-configmap.yaml
+++ b/helm/omcsi/templates/nginx-configmap.yaml
@@ -47,6 +47,18 @@ data:
             ssl_certificate     /etc/nginx/ssl/cert.pem;
             ssl_certificate_key /etc/nginx/ssl/key.pem;
 
+            location /api/plugins/ {
+                proxy_pass http://{{ include "omcsi.fullname" . }}-minecraft-wrapper-internal:{{ .Values.minecraftWrapper.internalService.wrapperPort }};
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+
+                proxy_connect_timeout 60s;
+                proxy_send_timeout    60s;
+                proxy_read_timeout    60s;
+            }
+
             location / {
                 proxy_pass http://{{ include "omcsi.webappHost" . }}:{{ .Values.webapp.service.port }};
                 proxy_set_header Host $host;

--- a/helm/omcsi/tests/network_policy_test.yaml
+++ b/helm/omcsi/tests/network_policy_test.yaml
@@ -85,9 +85,22 @@ tests:
       - isNull:
           path: spec.ingress[1].from[0].ipBlock
         documentIndex: 0
-      - isNotNull:
+      - isNull:
           path: spec.ingress[1].from[2].ipBlock
         documentIndex: 0
+      - isNotNull:
+          path: spec.ingress[1].from[3].ipBlock
+        documentIndex: 0
+
+  - it: nginx can reach minecraft-wrapper plugin deploy endpoint
+    asserts:
+      - equal:
+          path: spec.egress[1].ports[0].port
+          value: 8092
+        documentIndex: 2
+      - isNull:
+          path: spec.egress[1].to[0].ipBlock
+        documentIndex: 2
 
   - it: minecraft-wrapper policy restricts RCON to specific pods only
     asserts:


### PR DESCRIPTION
## Summary

- nginx previously forwarded **all** traffic to `webapp:8080`; `POST /api/plugins/deploy` returned 500 because the webapp has no such endpoint
- Added a `location /api/plugins/` block in `nginx-configmap.yaml` that proxies to `omcsi-minecraft-wrapper-internal:8092` (the ClusterIP service that exposes the wrapper REST API and RCON — port 8092 is not on the public NodePort service)
- Updated NetworkPolicies: nginx egress now allows outgoing connections to minecraft-wrapper on port 8092, and minecraft-wrapper ingress allows connections from nginx on port 8092
- Unit test updated to reflect the shifted `from` index (nginx inserted before the kubelet `ipBlock`) and a new test added to assert the nginx→wrapper routing

## Verified

Hot-deploy of a 12 MB plugin JAR via `POST https://<node-ip>/api/plugins/deploy` returned `Plugin deployed successfully` (200 OK) on the live single-node Hetzner cluster after this fix.

## Test plan

- [x] `helm unittest helm/omcsi` — all 115 tests pass
- [x] Live hot-deploy test: curl with `Authorization: Bearer <token>`, `pluginName=<name>.jar`, `file=@<path>` → 200 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_