### PR TITLE
fix: close RconClient socket when RCON authentication fails (#168)

### DIFF
--- a/alert-manager/src/main/java/com/openmc/alertmanager/rcon/RconClient.java
+++ b/alert-manager/src/main/java/com/openmc/alertmanager/rcon/RconClient.java
@@ -20,15 +20,27 @@ public class RconClient implements AutoCloseable {
     
     public RconClient(String host, int port, String password) throws IOException {
         socket = new Socket(host, port);
-        socket.setSoTimeout(5000);
-        out = new DataOutputStream(socket.getOutputStream());
-        in = new DataInputStream(socket.getInputStream());
-        
-        // Authenticate
-        sendPacket(SERVERDATA_AUTH, password);
-        RconPacket response = receivePacket();
-        if (response.getRequestId() == -1) {
-            throw new IOException("Authentication failed");
+        try {
+            socket.setSoTimeout(5000);
+            out = new DataOutputStream(socket.getOutputStream());
+            in = new DataInputStream(socket.getInputStream());
+
+            // Authenticate
+            sendPacket(SERVERDATA_AUTH, password);
+            RconPacket response = receivePacket();
+            if (response.getRequestId() == -1) {
+                throw new IOException("Authentication failed");
+            }
+        } catch (IOException e) {
+            // Construction failed after the socket was opened. Close it so the
+            // file descriptor isn't leaked: the caller's try-with-resources
+            // never runs close() on an instance whose constructor threw.
+            try {
+                socket.close();
+            } catch (IOException closeError) {
+                e.addSuppressed(closeError);
+            }
+            throw e;
         }
     }
     

--- a/alert-manager/src/test/java/com/openmc/alertmanager/rcon/RconClientTest.java
+++ b/alert-manager/src/test/java/com/openmc/alertmanager/rcon/RconClientTest.java
@@ -40,9 +40,9 @@ class RconClientTest {
     @Test
     @DisplayName("Should close its socket when RCON authentication fails (no FD leak)")
     void shouldCloseSocketWhenAuthenticationFails() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
         try (ServerSocket server = new ServerSocket(0)) {
             int port = server.getLocalPort();
-            ExecutorService executor = Executors.newSingleThreadExecutor();
 
             // The fake RCON server completes the auth handshake with a failure
             // (requestId == -1), then reports what it observes afterwards:
@@ -80,10 +80,11 @@ class RconClientTest {
             assertThrows(IOException.class, () -> new RconClient("localhost", port, "wrong-password"));
 
             int observed = postAuthRead.get(10, TimeUnit.SECONDS);
-            executor.shutdownNow();
             assertEquals(-1, observed,
                     "RconClient must close its socket after an auth failure; the server should "
                             + "observe EOF rather than a still-open connection.");
+        } finally {
+            executor.shutdownNow();
         }
     }
 

--- a/alert-manager/src/test/java/com/openmc/alertmanager/rcon/RconClientTest.java
+++ b/alert-manager/src/test/java/com/openmc/alertmanager/rcon/RconClientTest.java
@@ -1,4 +1,4 @@
-package com.openmc.webapp.rcon;
+package com.openmc.alertmanager.rcon;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.DisplayName;

--- a/web-app/src/main/java/com/openmc/webapp/rcon/RconClient.java
+++ b/web-app/src/main/java/com/openmc/webapp/rcon/RconClient.java
@@ -20,15 +20,27 @@ public class RconClient implements AutoCloseable {
     
     public RconClient(String host, int port, String password) throws IOException {
         socket = new Socket(host, port);
-        socket.setSoTimeout(5000);
-        out = new DataOutputStream(socket.getOutputStream());
-        in = new DataInputStream(socket.getInputStream());
-        
-        // Authenticate
-        sendPacket(SERVERDATA_AUTH, password);
-        RconPacket response = receivePacket();
-        if (response.getRequestId() == -1) {
-            throw new IOException("Authentication failed");
+        try {
+            socket.setSoTimeout(5000);
+            out = new DataOutputStream(socket.getOutputStream());
+            in = new DataInputStream(socket.getInputStream());
+
+            // Authenticate
+            sendPacket(SERVERDATA_AUTH, password);
+            RconPacket response = receivePacket();
+            if (response.getRequestId() == -1) {
+                throw new IOException("Authentication failed");
+            }
+        } catch (IOException e) {
+            // Construction failed after the socket was opened. Close it so the
+            // file descriptor isn't leaked: the caller's try-with-resources
+            // never runs close() on an instance whose constructor threw.
+            try {
+                socket.close();
+            } catch (IOException closeError) {
+                e.addSuppressed(closeError);
+            }
+            throw e;
         }
     }
     

--- a/web-app/src/test/java/com/openmc/webapp/rcon/RconClientTest.java
+++ b/web-app/src/test/java/com/openmc/webapp/rcon/RconClientTest.java
@@ -40,9 +40,9 @@ class RconClientTest {
     @Test
     @DisplayName("Should close its socket when RCON authentication fails (no FD leak)")
     void shouldCloseSocketWhenAuthenticationFails() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
         try (ServerSocket server = new ServerSocket(0)) {
             int port = server.getLocalPort();
-            ExecutorService executor = Executors.newSingleThreadExecutor();
 
             // The fake RCON server completes the auth handshake with a failure
             // (requestId == -1), then reports what it observes afterwards:
@@ -80,10 +80,11 @@ class RconClientTest {
             assertThrows(IOException.class, () -> new RconClient("localhost", port, "wrong-password"));
 
             int observed = postAuthRead.get(10, TimeUnit.SECONDS);
-            executor.shutdownNow();
             assertEquals(-1, observed,
                     "RconClient must close its socket after an auth failure; the server should "
                             + "observe EOF rather than a still-open connection.");
+        } finally {
+            executor.shutdownNow();
         }
     }
 


### PR DESCRIPTION
## Summary
- The `RconClient` constructor in **both** `web-app` and `alert-manager` opened a TCP socket and, on auth failure (or any I/O error during the handshake), threw **without closing it**. Because the instance is only owned by the caller after the constructor returns, a caller's `try (RconClient ...)` never runs `close()` on a half-constructed object — so the socket's file descriptor leaks. A wrong `RCON_PASSWORD` under repeated retries can exhaust the JVM's open-file limit.
- Fix: wrap the post-connect handshake in a `try/catch` that closes the socket (preserving the original exception via `addSuppressed`) before rethrowing.
- Added a regression test to each module: a fake RCON server completes the handshake with an auth-failure response, then asserts it observes **EOF** afterward — proving the client closed its socket. The test **fails against the pre-fix code** (verified by reverting the source change).

## Parity
No deployment-target surface is touched — pure application code, no `compose.yml` / `sample.env` / Helm / NetworkPolicy changes — so the dual-target Parity Charter is trivially satisfied.

## Test plan
- [x] `web-app`: `./gradlew test` (in CI) — `RconClientTest` passes.
- [x] `alert-manager`: `./gradlew build test` **run locally** (this module is not built/tested by CI) — `RconClientTest` passes.
- [x] Regression strength: reverted the `alert-manager` source fix and confirmed the new test fails.

Closes #168

_Skipped this cycle (deferred, not abandoned): #167 (JsonRepository data-safety refactor — own cycle), #169 (async server feedback — design-sized), #170 (lifecycle-script preflight — follow-up), #171 (RCON stale defaults — its fix edits `sample.env`, which open PR #162 is actively changing → conflict risk), #172 (healthcheck parity — cross-cutting compose+Helm, own cycle), and the older large feature requests (#11/#13/#15/#50/#65/#73/#114/#147/#148/#151)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_