### PR TITLE
fix: alert HTTP status checking and world response type

### DIFF
--- a/backup-manager/src/main/java/com/openmc/backupmanager/service/BackupService.java
+++ b/backup-manager/src/main/java/com/openmc/backupmanager/service/BackupService.java
@@ -305,8 +305,12 @@ public class BackupService {
             HttpEntity<Map<String, String>> request = new HttpEntity<>(alertData, headers);
 
             log.info("Sending alert to {}: {} ({})", alertManagerUrl, title, level);
-            restTemplate.postForEntity(alertManagerUrl, request, String.class);
-            log.info("Alert sent successfully");
+            var response = restTemplate.postForEntity(alertManagerUrl, request, String.class);
+            if (response.getStatusCode().is2xxSuccessful()) {
+                log.info("Alert sent successfully");
+            } else {
+                log.warn("Alert manager returned non-2xx status {} for alert: {}", response.getStatusCode(), title);
+            }
         } catch (Exception e) {
             log.warn("Failed to send alert: {}", e.getMessage());
         }

--- a/web-app/src/main/java/com/openmc/webapp/controller/ServerController.java
+++ b/web-app/src/main/java/com/openmc/webapp/controller/ServerController.java
@@ -8,6 +8,7 @@ import com.openmc.webapp.dto.PluginOperationResponse;
 import com.openmc.webapp.dto.WorldDeleteRequest;
 import com.openmc.webapp.dto.WorldListRequest;
 import com.openmc.webapp.dto.WorldListResponse;
+import com.openmc.webapp.dto.WorldOperationResponse;
 import com.openmc.webapp.model.ActivityTrackerStats;
 import com.openmc.webapp.model.DeploymentRecord;
 import com.openmc.webapp.model.LeaderboardEntry;
@@ -333,15 +334,15 @@ public class ServerController {
     
     @PostMapping(value = "/api/world/upload", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
-    public PluginOperationResponse uploadWorld(@RequestParam(required = false) String username,
+    public WorldOperationResponse uploadWorld(@RequestParam(required = false) String username,
                                                @RequestParam(required = false) String password,
                                                @RequestParam(value = "file", required = false) MultipartFile file) {
         if (username == null || username.isEmpty() || password == null || password.isEmpty()) {
-            return PluginOperationResponse.error("Missing username or password");
+            return WorldOperationResponse.error("Missing username or password");
         }
 
         if (file == null || file.isEmpty()) {
-            return PluginOperationResponse.error("No file provided");
+            return WorldOperationResponse.error("No file provided");
         }
 
         if (!validateCredentials(username, password)) {
@@ -349,12 +350,12 @@ public class ServerController {
                 "World Upload Authentication Failed",
                 "Failed authentication attempt for world upload endpoint"
             );
-            return PluginOperationResponse.error("Invalid username or password");
+            return WorldOperationResponse.error("Invalid username or password");
         }
 
         if (deployAuthToken == null || deployAuthToken.trim().isEmpty()) {
             logger.error("deploy.auth.token is not configured; world upload is unavailable");
-            return PluginOperationResponse.error("World upload is not configured on this server");
+            return WorldOperationResponse.error("World upload is not configured on this server");
         }
 
         boolean success = minecraftWrapperService.uploadWorld(file, deployAuthToken);
@@ -364,9 +365,9 @@ public class ServerController {
                 "World Uploaded Successfully",
                 String.format("User '%s' uploaded a new world map", username)
             );
-            return PluginOperationResponse.success("World uploaded successfully. Server is restarting.");
+            return WorldOperationResponse.success("World uploaded successfully. Server is restarting.");
         } else {
-            return PluginOperationResponse.error("World upload failed. Check server logs for details.");
+            return WorldOperationResponse.error("World upload failed. Check server logs for details.");
         }
     }
 
@@ -385,18 +386,18 @@ public class ServerController {
 
     @PostMapping(value = "/api/world/delete", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
-    public PluginOperationResponse deleteWorld(@RequestBody WorldDeleteRequest request) {
+    public WorldOperationResponse deleteWorld(@RequestBody WorldDeleteRequest request) {
         if (request.getUsername() == null || request.getUsername().isEmpty()
                 || request.getPassword() == null || request.getPassword().isEmpty()
                 || request.getName() == null || request.getName().isEmpty()) {
-            return PluginOperationResponse.error("Missing required parameters");
+            return WorldOperationResponse.error("Missing required parameters");
         }
         if (!validateCredentials(request.getUsername(), request.getPassword())) {
             alertNotificationService.sendWarningAlert(
                 "World Delete Authentication Failed",
                 "Failed authentication attempt for world delete endpoint"
             );
-            return PluginOperationResponse.error("Invalid username or password");
+            return WorldOperationResponse.error("Invalid username or password");
         }
 
         String result = worldService.deleteWorld(request.getName());
@@ -407,9 +408,9 @@ public class ServerController {
                 "World Deleted Successfully",
                 String.format("User '%s' deleted world: %s", request.getUsername(), request.getName())
             );
-            return PluginOperationResponse.success(result);
+            return WorldOperationResponse.success(result);
         } else {
-            return PluginOperationResponse.error(result);
+            return WorldOperationResponse.error(result);
         }
     }
 

--- a/web-app/src/main/java/com/openmc/webapp/dto/WorldOperationResponse.java
+++ b/web-app/src/main/java/com/openmc/webapp/dto/WorldOperationResponse.java
@@ -1,0 +1,37 @@
+package com.openmc.webapp.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public class WorldOperationResponse {
+    @Schema(description = "Whether the operation was successful")
+    private boolean success;
+    @Schema(description = "Success message")
+    private String message;
+    @Schema(description = "Error message if operation failed")
+    private String error;
+
+    public WorldOperationResponse() {}
+
+    public WorldOperationResponse(boolean success, String message, String error) {
+        this.success = success;
+        this.message = message;
+        this.error = error;
+    }
+
+    public static WorldOperationResponse success(String message) {
+        return new WorldOperationResponse(true, message, null);
+    }
+
+    public static WorldOperationResponse error(String error) {
+        return new WorldOperationResponse(false, null, error);
+    }
+
+    public boolean isSuccess() { return success; }
+    public void setSuccess(boolean success) { this.success = success; }
+
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+
+    public String getError() { return error; }
+    public void setError(String error) { this.error = error; }
+}

--- a/web-app/src/main/java/com/openmc/webapp/service/AlertNotificationService.java
+++ b/web-app/src/main/java/com/openmc/webapp/service/AlertNotificationService.java
@@ -7,6 +7,7 @@ import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
@@ -63,9 +64,12 @@ public class AlertNotificationService {
             HttpEntity<Map<String, Object>> request = new HttpEntity<>(alert, headers);
             
             String url = alertManagerUrl + "/api/alerts";
-            restTemplate.postForObject(url, request, String.class);
-            
-            logger.info("Alert sent successfully: {}", title);
+            ResponseEntity<String> response = restTemplate.postForEntity(url, request, String.class);
+            if (response.getStatusCode().is2xxSuccessful()) {
+                logger.info("Alert sent successfully: {}", title);
+            } else {
+                logger.warn("Alert manager returned non-2xx status {} for alert: {}", response.getStatusCode(), title);
+            }
         } catch (Exception e) {
             logger.error("Failed to send alert to alert manager: {}", title, e);
         }

--- a/web-app/src/test/java/com/openmc/webapp/service/AlertNotificationServiceTest.java
+++ b/web-app/src/test/java/com/openmc/webapp/service/AlertNotificationServiceTest.java
@@ -10,6 +10,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpEntity;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
@@ -23,43 +24,43 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 @DisplayName("AlertNotificationService Tests")
 class AlertNotificationServiceTest {
-    
+
     @Mock
     private RestTemplate restTemplate;
-    
+
     @Mock
     private RestTemplateBuilder restTemplateBuilder;
-    
+
     @Captor
     private ArgumentCaptor<HttpEntity<Map<String, Object>>> requestCaptor;
-    
+
     private AlertNotificationService alertService;
-    
+
     @BeforeEach
     void setUp() {
         when(restTemplateBuilder.setConnectTimeout(any())).thenReturn(restTemplateBuilder);
         when(restTemplateBuilder.setReadTimeout(any())).thenReturn(restTemplateBuilder);
         when(restTemplateBuilder.build()).thenReturn(restTemplate);
-        
+
         alertService = new AlertNotificationService(restTemplateBuilder);
         ReflectionTestUtils.setField(alertService, "alertManagerUrl", "http://test-alert-manager:8090");
         ReflectionTestUtils.setField(alertService, "alertsEnabled", true);
     }
-    
+
     @Test
     @DisplayName("Should send alert when enabled")
     void shouldSendAlertWhenEnabled() {
-        when(restTemplate.postForObject(anyString(), any(HttpEntity.class), eq(String.class)))
-                .thenReturn("Success");
-        
+        when(restTemplate.postForEntity(anyString(), any(HttpEntity.class), eq(String.class)))
+                .thenReturn(ResponseEntity.ok("Success"));
+
         alertService.sendAlert("Test Title", "Test Message", "INFO");
-        
-        verify(restTemplate, times(1)).postForObject(
+
+        verify(restTemplate, times(1)).postForEntity(
                 eq("http://test-alert-manager:8090/api/alerts"),
                 requestCaptor.capture(),
                 eq(String.class)
         );
-        
+
         Map<String, Object> alertBody = requestCaptor.getValue().getBody();
         assertNotNull(alertBody);
         assertEquals("Test Title", alertBody.get("title"));
@@ -67,114 +68,124 @@ class AlertNotificationServiceTest {
         assertEquals("INFO", alertBody.get("level"));
         assertEquals("webapp", alertBody.get("source"));
     }
-    
+
     @Test
     @DisplayName("Should not send alert when disabled")
     void shouldNotSendAlertWhenDisabled() {
         ReflectionTestUtils.setField(alertService, "alertsEnabled", false);
-        
+
         alertService.sendAlert("Test Title", "Test Message", "INFO");
-        
-        verify(restTemplate, never()).postForObject(anyString(), any(), any());
+
+        verify(restTemplate, never()).postForEntity(anyString(), any(), any());
     }
-    
+
     @Test
     @DisplayName("Should handle null title gracefully")
     void shouldHandleNullTitle() {
-        when(restTemplate.postForObject(anyString(), any(HttpEntity.class), eq(String.class)))
-                .thenReturn("Success");
-        
+        when(restTemplate.postForEntity(anyString(), any(HttpEntity.class), eq(String.class)))
+                .thenReturn(ResponseEntity.ok("Success"));
+
         assertDoesNotThrow(() -> alertService.sendAlert(null, "Test Message", "INFO"));
-        
-        verify(restTemplate, times(1)).postForObject(anyString(), any(), eq(String.class));
+
+        verify(restTemplate, times(1)).postForEntity(anyString(), any(), eq(String.class));
     }
-    
+
     @Test
     @DisplayName("Should handle null message gracefully")
     void shouldHandleNullMessage() {
-        when(restTemplate.postForObject(anyString(), any(HttpEntity.class), eq(String.class)))
-                .thenReturn("Success");
-        
+        when(restTemplate.postForEntity(anyString(), any(HttpEntity.class), eq(String.class)))
+                .thenReturn(ResponseEntity.ok("Success"));
+
         assertDoesNotThrow(() -> alertService.sendAlert("Test Title", null, "INFO"));
-        
-        verify(restTemplate, times(1)).postForObject(anyString(), any(), eq(String.class));
+
+        verify(restTemplate, times(1)).postForEntity(anyString(), any(), eq(String.class));
     }
-    
+
     @Test
     @DisplayName("Should handle alert manager unavailable")
     void shouldHandleAlertManagerUnavailable() {
-        when(restTemplate.postForObject(anyString(), any(HttpEntity.class), eq(String.class)))
+        when(restTemplate.postForEntity(anyString(), any(HttpEntity.class), eq(String.class)))
                 .thenThrow(new RestClientException("Connection refused"));
-        
-        // Should not throw exception - just log error
+
         assertDoesNotThrow(() -> alertService.sendAlert("Test Title", "Test Message", "INFO"));
-        
-        verify(restTemplate, times(1)).postForObject(anyString(), any(), eq(String.class));
+
+        verify(restTemplate, times(1)).postForEntity(anyString(), any(), eq(String.class));
     }
-    
+
+    @Test
+    @DisplayName("Should log warning when alert manager returns non-2xx")
+    void shouldLogWarningOnNon2xxResponse() {
+        when(restTemplate.postForEntity(anyString(), any(HttpEntity.class), eq(String.class)))
+                .thenReturn(ResponseEntity.internalServerError().build());
+
+        assertDoesNotThrow(() -> alertService.sendAlert("Test Title", "Test Message", "INFO"));
+
+        verify(restTemplate, times(1)).postForEntity(anyString(), any(), eq(String.class));
+    }
+
     @Test
     @DisplayName("Should send INFO alert")
     void shouldSendInfoAlert() {
-        when(restTemplate.postForObject(anyString(), any(HttpEntity.class), eq(String.class)))
-                .thenReturn("Success");
-        
+        when(restTemplate.postForEntity(anyString(), any(HttpEntity.class), eq(String.class)))
+                .thenReturn(ResponseEntity.ok("Success"));
+
         alertService.sendInfoAlert("Test Title", "Test Message");
-        
-        verify(restTemplate, times(1)).postForObject(
+
+        verify(restTemplate, times(1)).postForEntity(
                 anyString(),
                 requestCaptor.capture(),
                 eq(String.class)
         );
-        
+
         Map<String, Object> alertBody = requestCaptor.getValue().getBody();
         assertEquals("INFO", alertBody.get("level"));
     }
-    
+
     @Test
     @DisplayName("Should send WARNING alert")
     void shouldSendWarningAlert() {
-        when(restTemplate.postForObject(anyString(), any(HttpEntity.class), eq(String.class)))
-                .thenReturn("Success");
-        
+        when(restTemplate.postForEntity(anyString(), any(HttpEntity.class), eq(String.class)))
+                .thenReturn(ResponseEntity.ok("Success"));
+
         alertService.sendWarningAlert("Test Title", "Test Message");
-        
-        verify(restTemplate, times(1)).postForObject(
+
+        verify(restTemplate, times(1)).postForEntity(
                 anyString(),
                 requestCaptor.capture(),
                 eq(String.class)
         );
-        
+
         Map<String, Object> alertBody = requestCaptor.getValue().getBody();
         assertEquals("WARNING", alertBody.get("level"));
     }
-    
+
     @Test
     @DisplayName("Should send ERROR alert")
     void shouldSendErrorAlert() {
-        when(restTemplate.postForObject(anyString(), any(HttpEntity.class), eq(String.class)))
-                .thenReturn("Success");
-        
+        when(restTemplate.postForEntity(anyString(), any(HttpEntity.class), eq(String.class)))
+                .thenReturn(ResponseEntity.ok("Success"));
+
         alertService.sendErrorAlert("Test Title", "Test Message");
-        
-        verify(restTemplate, times(1)).postForObject(
+
+        verify(restTemplate, times(1)).postForEntity(
                 anyString(),
                 requestCaptor.capture(),
                 eq(String.class)
         );
-        
+
         Map<String, Object> alertBody = requestCaptor.getValue().getBody();
         assertEquals("ERROR", alertBody.get("level"));
     }
-    
+
     @Test
     @DisplayName("Should construct correct URL")
     void shouldConstructCorrectUrl() {
-        when(restTemplate.postForObject(anyString(), any(HttpEntity.class), eq(String.class)))
-                .thenReturn("Success");
-        
+        when(restTemplate.postForEntity(anyString(), any(HttpEntity.class), eq(String.class)))
+                .thenReturn(ResponseEntity.ok("Success"));
+
         alertService.sendAlert("Test Title", "Test Message", "INFO");
-        
-        verify(restTemplate).postForObject(
+
+        verify(restTemplate).postForEntity(
                 eq("http://test-alert-manager:8090/api/alerts"),
                 any(),
                 eq(String.class)


### PR DESCRIPTION
## Summary

- Fixes silent false-success logging when alert manager returns non-2xx or is unreachable (closes #185)
- Introduces `WorldOperationResponse` DTO and uses it for world endpoints instead of `PluginOperationResponse` (closes #186)

## Changes

### Alert HTTP status fix (#185)

**`AlertNotificationService`** — switched from `postForObject` (discards response) to `postForEntity`; now checks `response.getStatusCode().is2xxSuccessful()` and logs a warning on non-2xx instead of always logging success.

**`BackupService.sendAlert`** — same fix applied.

**`AlertNotificationServiceTest`** — updated all stubs and verifications from `postForObject` to `postForEntity`; added a new test case for the non-2xx warning path.

### World response type (#186)

Added `WorldOperationResponse` DTO (identical structure to `PluginOperationResponse` — `success`, `message`, `error` fields with static factories). Wired into `ServerController`:
- `POST /api/world/upload` now returns `WorldOperationResponse`
- `POST /api/world/delete` now returns `WorldOperationResponse`

JSON field names are unchanged so no client-side updates are needed.

_Reviewed by Daniel Stephenson via Claude._