### PR TITLE
fix(web-app): make JsonRepository.save() atomic and propagate write failures

### DIFF
--- a/web-app/src/main/java/com/openmc/webapp/repository/JsonRepository.java
+++ b/web-app/src/main/java/com/openmc/webapp/repository/JsonRepository.java
@@ -8,6 +8,11 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -80,18 +85,32 @@ public abstract class JsonRepository<T> implements Repository<T> {
     
     @Override
     public void save(List<T> entities) {
+        Instant cutoff = Instant.now().minus(retentionPeriod);
+        List<T> entitiesToSave = entities.stream()
+                .filter(entity -> getEntityTimestamp(entity).isAfter(cutoff))
+                .collect(Collectors.toList());
+
+        // Write to a sibling temp file first, then rename atomically so a crash
+        // mid-write never leaves the data file partially written.
+        Path target = dataFile.toPath();
+        Path tmp = null;
         try {
-            // Filter out entities older than retention period
-            Instant cutoff = Instant.now().minus(retentionPeriod);
-            List<T> entitiesToSave = entities.stream()
-                    .filter(entity -> getEntityTimestamp(entity).isAfter(cutoff))
-                    .collect(Collectors.toList());
-            
-            objectMapper.writerWithDefaultPrettyPrinter()
-                    .writeValue(dataFile, entitiesToSave);
+            tmp = Files.createTempFile(target.getParent(), ".json-repo-", ".tmp");
+            objectMapper.writerWithDefaultPrettyPrinter().writeValue(tmp.toFile(), entitiesToSave);
+            try {
+                Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            } catch (AtomicMoveNotSupportedException ignored) {
+                Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING);
+            }
+            tmp = null; // successfully moved; skip deletion in finally
             logger.debug("Saved {} entities to {}", entitiesToSave.size(), dataFile.getAbsolutePath());
         } catch (IOException e) {
             logger.error("Failed to save entities to {}: {}", dataFile.getAbsolutePath(), e.getMessage());
+            throw new UncheckedIOException("Failed to save entities to " + dataFile.getAbsolutePath(), e);
+        } finally {
+            if (tmp != null) {
+                try { Files.deleteIfExists(tmp); } catch (IOException ignored) {}
+            }
         }
     }
     

--- a/web-app/src/test/java/com/openmc/webapp/repository/DeploymentRecordRepositoryTest.java
+++ b/web-app/src/test/java/com/openmc/webapp/repository/DeploymentRecordRepositoryTest.java
@@ -3,8 +3,13 @@ package com.openmc.webapp.repository;
 import com.openmc.webapp.config.TestDataStorageConfig;
 import com.openmc.webapp.model.DeploymentRecord;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -105,6 +110,55 @@ class DeploymentRecordRepositoryTest {
 
         assertEquals(1, loadedRecords.size());
         assertEquals("RecentPlugin.jar", loadedRecords.get(0).getPluginName());
+    }
+
+    @Test
+    @DisplayName("Should throw UncheckedIOException when data directory is not writable")
+    void shouldThrowWhenDirectoryNotWritable(@TempDir Path tempDir) throws Exception {
+        Path readOnlyDir = tempDir.resolve("ro");
+        Files.createDirectory(readOnlyDir);
+
+        TestDataStorageConfig cfg = new TestDataStorageConfig(readOnlyDir.toString());
+        DeploymentRecordRepository repo = new DeploymentRecordRepository(cfg);
+
+        // Seed a record so there is something to save
+        List<DeploymentRecord> records = createTestRecords(1);
+
+        // Make the directory read-only so Files.createTempFile fails
+        Files.setPosixFilePermissions(readOnlyDir, PosixFilePermissions.fromString("r-xr-xr-x"));
+        try {
+            assertThrows(UncheckedIOException.class, () -> repo.save(records));
+        } finally {
+            Files.setPosixFilePermissions(readOnlyDir, PosixFilePermissions.fromString("rwxr-xr-x"));
+        }
+    }
+
+    @Test
+    @DisplayName("Should leave existing data intact when a save fails")
+    void shouldPreserveExistingDataOnSaveFailure(@TempDir Path tempDir) throws Exception {
+        Path dataDir = tempDir.resolve("data");
+        Files.createDirectory(dataDir);
+
+        TestDataStorageConfig cfg = new TestDataStorageConfig(dataDir.toString());
+        DeploymentRecordRepository repo = new DeploymentRecordRepository(cfg);
+
+        // Write an initial record successfully
+        List<DeploymentRecord> initial = createTestRecords(1);
+        repo.save(initial);
+        assertEquals(1, repo.findAll().size());
+
+        // Now make the directory read-only so the next save fails
+        Files.setPosixFilePermissions(dataDir, PosixFilePermissions.fromString("r-xr-xr-x"));
+        try {
+            assertThrows(UncheckedIOException.class, () -> repo.save(createTestRecords(2)));
+        } finally {
+            Files.setPosixFilePermissions(dataDir, PosixFilePermissions.fromString("rwxr-xr-x"));
+        }
+
+        // Original data must still be intact
+        List<DeploymentRecord> afterFailure = repo.findAll();
+        assertEquals(1, afterFailure.size());
+        assertEquals(initial.get(0).getPluginName(), afterFailure.get(0).getPluginName());
     }
 
     private List<DeploymentRecord> createTestRecords(int count) {


### PR DESCRIPTION
## Summary
- `JsonRepository.save()` previously wrote directly to the data file, so a JVM crash mid-write left a partially-written (corrupt) JSON file — the next load would silently return an empty list and overwrite the file, losing all history
- Write failures were also swallowed: the `catch (IOException)` logged the error but returned normally, so callers had no way to know the save failed

## Changes

**`JsonRepository.java`**
- Atomic write: serialize to a sibling temp file (`Files.createTempFile` in the same directory), then rename it over the data file (`Files.move` with `ATOMIC_MOVE`, falling back to `REPLACE_EXISTING` if the filesystem doesn't support atomic moves). The data file is only replaced once the full content is on disk.
- Error propagation: on failure, wrap the `IOException` in `UncheckedIOException` and rethrow instead of swallowing. The `Repository<T>` interface signature is unchanged.

**`DeploymentRecordRepositoryTest.java`**
- `shouldThrowWhenDirectoryNotWritable` — verifies `UncheckedIOException` is raised when the data directory is read-only
- `shouldPreserveExistingDataOnSaveFailure` — verifies the original data file is untouched when a write fails (atomic-write guarantee)

## Test plan
- [x] All web-app tests pass (`./gradlew test`)

Closes #167

_Filed by Claude during an automated triage pass; claims above were verified against source._