### PR TITLE
fix(alert-manager): correct stale RCON defaults in application.properties

### DIFF
--- a/alert-manager/src/main/resources/application.properties
+++ b/alert-manager/src/main/resources/application.properties
@@ -9,10 +9,10 @@ discord.webhook.url=${DISCORD_WEBHOOK_URL:}
 discord.enabled=${DISCORD_ENABLED:false}
 
 # Minecraft RCON configuration
-minecraft.rcon.host=${MINECRAFT_RCON_HOST:mcserver}
+minecraft.rcon.host=${MINECRAFT_RCON_HOST:minecraft-wrapper}
 minecraft.rcon.port=${MINECRAFT_RCON_PORT:25575}
 minecraft.rcon.password=${MINECRAFT_RCON_PASSWORD:}
-minecraft.rcon.enabled=${MINECRAFT_RCON_ENABLED:false}
+minecraft.rcon.enabled=${MINECRAFT_RCON_ENABLED:true}
 
 # HTTP client timeouts (in seconds)
 http.client.connect-timeout-seconds=5


### PR DESCRIPTION
## Summary
`alert-manager/src/main/resources/application.properties` had two stale fallback defaults that contradicted every other deployment path:

| Property | Old default | Correct default |
|---|---|---|
| `minecraft.rcon.host` | `mcserver` | `minecraft-wrapper` |
| `minecraft.rcon.enabled` | `false` | `true` |

Both `compose.yml` and the Helm chart already inject the correct values (`minecraft-wrapper` / `true`), so production deployments were unaffected. The stale defaults only bite when running the jar directly (e.g. local dev without Docker), causing RCON to silently connect to the wrong host and be disabled by default.

Closes #171

_Filed by Claude during an automated triage pass; claims above were verified against source._

---

_drafted by Claude on behalf of Daniel Stephenson_