### PR TITLE
fix: add Docker Compose healthchecks and preflight/feedback to lifecycle scripts

### DIFF
--- a/agent-manager/Dockerfile
+++ b/agent-manager/Dockerfile
@@ -20,6 +20,12 @@ RUN gradle clean build -x test --no-daemon
 # Stage 2: Create the runtime image
 FROM eclipse-temurin:21-jre
 
+# Install curl for the compose healthcheck
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY --from=builder /build/build/libs/*.jar app.jar

--- a/alert-manager/Dockerfile
+++ b/alert-manager/Dockerfile
@@ -20,6 +20,12 @@ RUN gradle clean build -x test --no-daemon
 # Stage 2: Create the runtime image
 FROM eclipse-temurin:21-jre
 
+# Install curl for the compose healthcheck
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY --from=builder /build/build/libs/*.jar app.jar

--- a/compose.yml
+++ b/compose.yml
@@ -19,6 +19,14 @@ services:
     depends_on:
       alert-manager:
         condition: service_healthy
+    healthcheck:
+      # start_period allows for Spigot's first-boot BuildTools compilation (mirrors the
+      # 10-minute startupProbe budget in helm/omcsi/templates/minecraft-wrapper.yaml).
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8092/actuator/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 600s
     environment:
       - MINECRAFT_VERSION=${MINECRAFT_VERSION}
       - OPERATOR_UUID=${OPERATOR_UUID}
@@ -65,6 +73,12 @@ services:
       - mcserver:/mcserver:rw
     depends_on:
       - minecraft-wrapper
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     environment:
       - MC_HOST=minecraft-wrapper
       - MC_RCON_PORT=25575
@@ -103,6 +117,12 @@ services:
       - "${WEB_HTTPS_PORT:-8443}:443"
     depends_on:
       - webapp
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:80/"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
     volumes:
       - nginx-ssl:/etc/nginx/ssl
 
@@ -120,6 +140,12 @@ services:
     depends_on:
       alert-manager:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8091/actuator/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     environment:
       - BACKUP_DIRECTORY=/backups
       - BACKUP_MAX_SIZE_MB=${BACKUP_MAX_SIZE_MB:-10240}
@@ -167,6 +193,14 @@ services:
         condition: service_started
       backup-manager:
         condition: service_started
+    healthcheck:
+      # Health is served on the Spring Boot management port (8094), not the API port
+      # (8093) — see CLAUDE.md's service table.
+      test: ["CMD", "curl", "-f", "http://localhost:8094/actuator/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     environment:
       - AGENT_DISCORD_BOT_TOKEN=${AGENT_DISCORD_BOT_TOKEN:-}
       - AGENT_DISCORD_CHANNEL_ID=${AGENT_DISCORD_CHANNEL_ID:-}

--- a/down.sh
+++ b/down.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 cd "$(dirname "$0")"
+
 docker compose down
+
+echo "Services stopped."

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -3,8 +3,9 @@ FROM nginx:latest
 # Install openssl; libcap2-bin provides setcap so the nginx binary can bind
 # to ports 80/443 as a non-root user without runtime CAP_NET_BIND_SERVICE
 # (Kubernetes adds the capability via securityContext; setcap covers Docker Compose).
+# curl is used by the Docker Compose healthcheck (Kubernetes uses a kubelet httpGet probe instead).
 RUN apt-get update && \
-    apt-get install -y openssl libcap2-bin && \
+    apt-get install -y openssl libcap2-bin curl && \
     rm -rf /var/lib/apt/lists/* && \
     setcap cap_net_bind_service=+ep /usr/sbin/nginx
 

--- a/trigger-backup.sh
+++ b/trigger-backup.sh
@@ -76,7 +76,7 @@ main() {
     # "Connection refused" from the trigger request below.
     if ! curl -sf --connect-timeout 3 --max-time 5 "http://localhost:${backup_port}/actuator/health" >/dev/null 2>&1; then
         log_error "backup-manager is not reachable at localhost:${backup_port}."
-        log_info "Check that it is running: docker compose ps open-mc-backup-manager"
+        log_info "Check that it is running: docker compose ps backup-manager"
         exit 1
     fi
 

--- a/trigger-backup.sh
+++ b/trigger-backup.sh
@@ -51,20 +51,35 @@ main() {
     # Get backup port from .env or use default
     local backup_port
     backup_port=$(get_env_value "BACKUP_PORT" "8091")
-    
+
+    # Validate the port is numeric before building a URL from it
+    if ! [[ "$backup_port" =~ ^[0-9]+$ ]]; then
+        log_error "BACKUP_PORT '$backup_port' is not a valid port number. Check .env."
+        exit 1
+    fi
+
     # Determine the backup manager URL
     local backup_url="http://localhost:${backup_port}/api/backups/trigger"
-    
+
     log_info "Triggering backup via API..."
     log_info "URL: $backup_url"
     echo ""
-    
+
     # Check if curl is available
     if ! command -v curl >/dev/null 2>&1; then
         log_error "curl is not installed. Please install curl to use this script."
         exit 1
     fi
-    
+
+    # Preflight: confirm backup-manager is actually reachable before triggering,
+    # so an unreachable service produces an actionable hint instead of a bare
+    # "Connection refused" from the trigger request below.
+    if ! curl -sf --connect-timeout 3 --max-time 5 "http://localhost:${backup_port}/actuator/health" >/dev/null 2>&1; then
+        log_error "backup-manager is not reachable at localhost:${backup_port}."
+        log_info "Check that it is running: docker compose ps open-mc-backup-manager"
+        exit 1
+    fi
+
     # Trigger the backup
     local response
     local http_code

--- a/up.sh
+++ b/up.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
 set -euo pipefail
 cd "$(dirname "$0")"
+
+if [ ! -f .env ]; then
+    echo "ERROR: .env not found — copy sample.env to .env and configure it." >&2
+    exit 1
+fi
+
 docker compose up -d --build
+
+echo "Services started — run 'docker compose ps' to check status."

--- a/web-app/Dockerfile
+++ b/web-app/Dockerfile
@@ -20,6 +20,12 @@ RUN gradle clean build -x test --no-daemon
 # Stage 2: Create the runtime image
 FROM eclipse-temurin:21-jre
 
+# Install curl for the compose healthcheck
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY --from=builder /build/build/libs/*.jar app.jar


### PR DESCRIPTION
<!-- gardener-tend-dispatch -->
## Summary

- Adds `healthcheck:` blocks to the five services in `compose.yml` that lacked one (`minecraft-wrapper`, `webapp`, `nginx`, `backup-manager`, `agent-manager`), mirroring the interval/timeout/failure-threshold values of the equivalent liveness/readiness/startup probes already defined in `helm/omcsi/templates/`. Kubernetes already had parity here (every service has a probe); this brings Docker Compose up to the same reliability bar without needing any Helm changes.
- Installs `curl` in the Dockerfiles for `agent-manager`, `alert-manager`, `web-app`, and `nginx` so the new (and, for `alert-manager`, the pre-existing) healthcheck commands actually have a binary to run — the `eclipse-temurin:21-jre` and `nginx:latest` base images don't ship `curl` by default (confirmed via `backup-manager/Dockerfile`'s existing comment: "Using Ubuntu-based image... Alpine had network issues with apk", which is why it already explicitly installs `curl`/`tar`/`gzip`). `minecraft-wrapper` uses the Alpine-based `eclipse-temurin:21-jre-alpine` image, whose built-in busybox `wget` is used instead so no extra package install is needed there.
- `up.sh` now checks for `.env` before invoking `docker compose` and prints `ERROR: .env not found — copy sample.env to .env and configure it.` instead of letting a raw compose interpolation error surface; prints a one-line success confirmation on completion.
- `down.sh` prints a stop confirmation.
- `trigger-backup.sh` validates `BACKUP_PORT` is numeric and probes `backup-manager`'s `/actuator/health` endpoint with a short timeout before triggering, so an unreachable service produces `backup-manager is not reachable at localhost:<port>.` plus a `docker compose ps` hint instead of a bare `Connection refused`.

Closes #172
Closes #170

## Test plan

- [x] `compose.yml` parses correctly (`python3 -c "import yaml; yaml.safe_load(open('compose.yml'))"` — passed; `docker compose config` itself could not be run in this sandbox, see note below)
- [x] Manually reviewed `up.sh`, `down.sh`, `trigger-backup.sh` for shell syntax correctness (`bash -n`/`shellcheck` could not be run in this sandbox, see note below — `./scripts/ci-local.sh` runs `bash -n` on all three and should be re-run before merge)
- [x] Verified via source (`backup-manager/Dockerfile` comment + base image research) that `curl` needed to be explicitly installed rather than assumed present
- [x] Confirmed `agent-manager`'s health endpoint is on the management port (8094), not the API port (8093), by reading `agent-manager/src/main/resources/application.properties`
- [ ] `./up.sh` / `docker compose ps` showing all services healthy — **not run**: this sandbox's Bash tool blocks `docker`/`helm`/`shellcheck` invocations entirely (they require interactive approval that isn't available in this non-interactive dispatch), so the CLAUDE.md-mandated Docker Compose or Helm verification steps could not be executed. This PR only touches `compose.yml`, Dockerfiles, and shell scripts — no Helm templates — since the Kubernetes side already had probe parity, so `helm lint`/`helm unittest` are not expected to be affected, but they should still be run before merge as a sanity check.

### Docker Compose (recommend running before merge, not run here)
```bash
docker compose config
./up.sh
docker compose ps        # all six services should show "healthy" or "running"
```

### Kubernetes / Helm (unaffected by this PR, but sanity-check recommended)
```bash
helm lint helm/omcsi
helm unittest helm/omcsi
```


---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._