### PR TITLE
feat(helm): add optional HorizontalPodAutoscaler for nginx

### DIFF
--- a/docs/KUBERNETES_IMPROVEMENTS.md
+++ b/docs/KUBERNETES_IMPROVEMENTS.md
@@ -83,14 +83,13 @@ This document captures issues, limitations, and improvement opportunities surfac
 
 ---
 
-## 7. Horizontal Pod Autoscaler (HPA)
+## 7. Horizontal Pod Autoscaler (HPA) 🟡 Partially Resolved
 
 **Problem:** No HPA is configured for any service. The Minecraft server is intentionally limited to a single replica, but supporting services (webapp, nginx, alert-manager) could benefit from autoscaling under load.
 
-**Suggested improvements:**
-- Add optional HPA templates for `webapp`, `nginx`, and `alert-manager` (gated by `autoscaling.enabled` in `values.yaml`).
-- Define sensible CPU/memory scaling thresholds.
-- Document that `minecraft-wrapper` cannot be horizontally scaled (single-instance constraint).
+**Resolution (nginx only):** An optional HPA template was added to `helm/omcsi/templates/hpa.yaml`, gated by `nginx.autoscaling.enabled` in `values.yaml` (default `false`), targeting CPU utilization. `nginx` is the only supporting service scaled because it has no PVC and no in-memory session state; the Deployment's `replicas` field is omitted once autoscaling is enabled so Helm upgrades don't fight the HPA's chosen replica count.
+
+**Remaining work — `webapp` and `alert-manager`:** both mount a `ReadWriteOnce` PVC (`webapp` already `fail`s the template at `replicaCount > 1` for this reason), so scaling them requires first resolving the shared-PVC constraint — tracked in [#147](https://github.com/dmccoystephenson/open-mc-server-infrastructure/issues/147). `minecraft-wrapper` remains single-instance by design (owns world data + RCON) and is not a candidate for HPA.
 
 **Priority:** Low — OMCSI is typically a small-scale deployment; autoscaling adds value for larger communities.
 

--- a/helm/omcsi/templates/hpa.yaml
+++ b/helm/omcsi/templates/hpa.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.nginx.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "omcsi.fullname" . }}-nginx
+  labels:
+    {{- include "omcsi.labels" . | nindent 4 }}
+    {{- include "omcsi.selectorLabels" (dict "root" . "component" "nginx") | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "omcsi.fullname" . }}-nginx
+  minReplicas: {{ .Values.nginx.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.nginx.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.nginx.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/helm/omcsi/templates/nginx.yaml
+++ b/helm/omcsi/templates/nginx.yaml
@@ -6,7 +6,9 @@ metadata:
     {{- include "omcsi.labels" . | nindent 4 }}
     {{- include "omcsi.selectorLabels" (dict "root" . "component" "nginx") | nindent 4 }}
 spec:
+  {{- if not .Values.nginx.autoscaling.enabled }}
   replicas: {{ .Values.nginx.replicaCount }}
+  {{- end }}
   strategy:
     type: RollingUpdate
   selector:

--- a/helm/omcsi/tests/hpa_test.yaml
+++ b/helm/omcsi/tests/hpa_test.yaml
@@ -1,0 +1,83 @@
+suite: HorizontalPodAutoscaler
+templates:
+  - templates/hpa.yaml
+  - templates/nginx.yaml
+set:
+  secrets.rconPassword: ci
+  secrets.adminPassword: ci
+tests:
+  - it: renders no HPA when nginx.autoscaling.enabled is false (default)
+    templates:
+      - templates/hpa.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders an nginx HPA when nginx.autoscaling.enabled is true
+    set:
+      nginx.autoscaling.enabled: true
+    templates:
+      - templates/hpa.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isAPIVersion:
+          of: autoscaling/v2
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - equal:
+          path: spec.scaleTargetRef.kind
+          value: Deployment
+      - equal:
+          path: spec.minReplicas
+          value: 1
+      - equal:
+          path: spec.maxReplicas
+          value: 3
+      - equal:
+          path: spec.metrics[0].resource.target.averageUtilization
+          value: 70
+
+  - it: honors custom min/max/target overrides
+    set:
+      nginx.autoscaling.enabled: true
+      nginx.autoscaling.minReplicas: 2
+      nginx.autoscaling.maxReplicas: 5
+      nginx.autoscaling.targetCPUUtilizationPercentage: 50
+    templates:
+      - templates/hpa.yaml
+    asserts:
+      - equal:
+          path: spec.minReplicas
+          value: 2
+      - equal:
+          path: spec.maxReplicas
+          value: 5
+      - equal:
+          path: spec.metrics[0].resource.target.averageUtilization
+          value: 50
+
+  - it: nginx Deployment omits replicas when autoscaling is enabled
+    set:
+      nginx.autoscaling.enabled: true
+    templates:
+      - templates/nginx.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+      skipEmptyTemplates: true
+    asserts:
+      - notExists:
+          path: spec.replicas
+
+  - it: nginx Deployment sets replicas from replicaCount when autoscaling is disabled
+    templates:
+      - templates/nginx.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+      skipEmptyTemplates: true
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 1

--- a/helm/omcsi/tests/hpa_test.yaml
+++ b/helm/omcsi/tests/hpa_test.yaml
@@ -1,7 +1,6 @@
 suite: HorizontalPodAutoscaler
-templates:
-  - templates/hpa.yaml
-  - templates/nginx.yaml
+# nginx.yaml references nginx-configmap.yaml (checksum annotation), so both
+# must be rendered together whenever nginx.yaml is included (see nginx_test.yaml).
 set:
   secrets.rconPassword: ci
   secrets.adminPassword: ci
@@ -62,6 +61,7 @@ tests:
       nginx.autoscaling.enabled: true
     templates:
       - templates/nginx.yaml
+      - templates/nginx-configmap.yaml
     documentSelector:
       path: kind
       value: Deployment
@@ -73,6 +73,7 @@ tests:
   - it: nginx Deployment sets replicas from replicaCount when autoscaling is disabled
     templates:
       - templates/nginx.yaml
+      - templates/nginx-configmap.yaml
     documentSelector:
       path: kind
       value: Deployment

--- a/helm/omcsi/values.yaml
+++ b/helm/omcsi/values.yaml
@@ -149,6 +149,18 @@ nginx:
     # --service-node-port-range to include them (e.g. 80-32767).
     httpNodePort: ""
     httpsNodePort: ""
+  # nginx has no PVC and no in-memory session state, so it is the only
+  # supporting service that can be horizontally scaled safely today.
+  # webapp and alert-manager are excluded: both mount a ReadWriteOnce PVC
+  # (webapp already `fail`s at replicaCount > 1 for this reason), so scaling
+  # them requires resolving the shared-PVC constraint first — see #147.
+  # Requires the metrics-server (or equivalent) API to be installed in the
+  # cluster; replicaCount above is ignored once enabled (HPA owns replicas).
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 70
   tls:
     # When true, a self-signed certificate is generated via an init container
     # (same behaviour as the Docker Compose setup).


### PR DESCRIPTION
## Summary
- Adds an optional CPU-based `HorizontalPodAutoscaler` for `nginx`, gated by `nginx.autoscaling.enabled` (default `false`), addressing part of #148.
- Scoped to `nginx` only: it's the sole supporting service with no PVC and no in-memory session state, so it's safe to scale today. `webapp` and `alert-manager` both mount a `ReadWriteOnce` PVC (`webapp`'s template already `fail`s at `replicaCount > 1` for exactly this reason), so scaling either requires resolving the shared-PVC constraint first — tracked in #147. Implementing HPA for those two now would have produced a template that either can't schedule extra replicas or risks concurrent writes to a single-writer volume.
- The nginx Deployment's `replicas` field is omitted once autoscaling is enabled, so `helm upgrade` doesn't fight the HPA's chosen replica count.
- `docs/KUBERNETES_IMPROVEMENTS.md` item 7 updated to reflect the partial resolution and link the remaining work to #147.
- No Docker Compose changes: HPA is a Kubernetes-only concept with no Compose equivalent (same precedent as the existing PodDisruptionBudget / NetworkPolicy chart features, which are also Kubernetes-only).

## Verification
- `helm lint` / `helm unittest` could not be run locally in this sandbox session (the `helm` binary requires an approval this headless session has no human available to grant — see repo `CLAUDE.md` verification section). A new unittest suite (`helm/omcsi/tests/hpa_test.yaml`) was added covering: no HPA rendered by default, HPA rendered with correct `scaleTargetRef`/thresholds when enabled, custom min/max/target overrides, and that the nginx Deployment's `replicas` field is present/absent correctly depending on the toggle. **CI's `helm-lint` and `helm-unit-test` jobs are the real verification anchor for this PR** — please treat a green CI run as the actual pass/fail signal here, not this description.
- No Java/Gradle modules touched.

## Test plan
- [ ] CI `helm-lint` job passes
- [ ] CI `helm-unit-test` job passes (includes the new `hpa_test.yaml` suite)
- [ ] CI `helm-deploy-test` (kind cluster) job passes
- [ ] Manual: `helm template omcsi helm/omcsi --set nginx.autoscaling.enabled=true` renders an `autoscaling/v2` HPA targeting the nginx Deployment

<!-- gardener-tend-dispatch -->


---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._