### PR TITLE
docs: document RWX StorageClass option and evaluate shared-PVC access

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,30 @@ helm install omcsi ./helm/omcsi --namespace omcsi --create-namespace \
 
 When using Terraform, the `storage_class` variable is set automatically (defaults to `gp2` on AWS, `linode-block-storage-retain` on Linode).
 
+##### Multi-Node Scheduling & RWX StorageClasses
+
+By default, all four PVCs (`mcserver`, `webappData`, `alertManagerData`, `backups`) use `ReadWriteOnce` (RWO). An RWO volume can only be mounted read-write by pods on a single node at a time, so the chart uses pod affinity (`preferredDuringSchedulingIgnoredDuringExecution`) to encourage `minecraft-wrapper`, `webapp`, and `backup-manager` to co-locate on the same node as the `mcserver` PVC. This is a *preference*, not a requirement — on a resource-constrained multi-node cluster, the scheduler can still place these pods on different nodes, which will leave the non-co-located pod's volume mount stuck.
+
+If you run a multi-node cluster and want to remove this constraint entirely, switch the relevant PVC(s) to `ReadWriteMany` (RWX) with a StorageClass that supports it:
+
+```bash
+helm install omcsi ./helm/omcsi --namespace omcsi --create-namespace \
+  --set secrets.rconPassword=changeme \
+  --set secrets.adminPassword=strongpassword \
+  --set persistence.mcserver.accessMode=ReadWriteMany \
+  --set persistence.mcserver.storageClass=nfs-client
+```
+
+**RWX-capable StorageClass options:**
+
+| Option | Notes |
+|---|---|
+| NFS (e.g. [`nfs-subdir-external-provisioner`](https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner)) | Simplest self-hosted option; works on any cluster with an NFS server reachable from all nodes |
+| AWS EFS (via the [`aws-efs-csi-driver`](https://github.com/kubernetes-sigs/aws-efs-csi-driver)) | Managed RWX storage on EKS; requires the EFS CSI driver add-on and an EFS file system |
+| [Longhorn](https://longhorn.io/) | Self-hosted distributed block storage with RWX support; works on any cluster (bare metal, Hetzner, etc.) |
+
+This is a Kubernetes-only concern — Docker Compose runs all services on a single host, so there is no equivalent scheduling constraint to document there.
+
 **Troubleshooting**
 
 | Symptom | Likely cause | Fix |

--- a/docs/KUBERNETES_IMPROVEMENTS.md
+++ b/docs/KUBERNETES_IMPROVEMENTS.md
@@ -70,16 +70,19 @@ This document captures issues, limitations, and improvement opportunities surfac
 
 ---
 
-## 6. Shared PVC Scheduling Constraints
+## 6. Shared PVC Scheduling Constraints ✅ Resolved (documentation)
 
 **Problem:** The mcserver PVC uses `ReadWriteOnce` (RWO), which means all pods mounting it must run on the same node. The chart uses `preferredDuringSchedulingIgnoredDuringExecution` pod affinity to encourage co-location, but this can fail on multi-node clusters if the node with the PVC has insufficient resources.
 
-**Suggested improvements:**
-- Document the option to use a `ReadWriteMany` (RWX) StorageClass (e.g., NFS, EFS, Longhorn) for multi-node flexibility.
-- Consider a sidecar or init container pattern where the Minecraft wrapper is the sole PVC owner and exposes data via RCON/API, removing the need for other services to mount the same PVC.
-- Evaluate whether the webapp truly needs direct filesystem access to `/mcserver` or could use the wrapper API instead.
+**Resolution:** `persistence.mcserver.accessMode` was already a plain Helm value (no code change required) — switching to `ReadWriteMany` only needed documenting. The [Multi-Node Scheduling & RWX StorageClasses](../README.md#multi-node-scheduling--rwx-storageclasses) section in the README now covers this: setting `accessMode: ReadWriteMany` with an RWX-capable StorageClass (NFS, AWS EFS via the EFS CSI driver, Longhorn) removes the co-location requirement entirely, since all pods can then mount the PVC regardless of which node they land on.
 
-**Priority:** Low — the current affinity rules work for typical 2-node clusters. Only relevant for larger or more constrained environments.
+**Evaluation — does `webapp` / `backup-manager` need direct filesystem access?** Yes, for both, today:
+- `webapp`'s `WorldService` and `PluginService` list, upload, and delete files directly under `/mcserver` (world directories, plugin jars) — see `web-app/src/main/java/com/openmc/webapp/service/WorldService.java` and `PluginService.java`. Routing this through `minecraft-wrapper`'s REST API instead would mean adding streaming file-transfer and directory-listing endpoints to the wrapper for every operation webapp currently does with `java.nio.file` calls — a much larger change than the low priority of this issue justifies.
+- `backup-manager`'s `BackupService` runs `tar` directly against the whole `sourceDirectory` (`/mcserver`) to produce `mcserver-backup.tar.gz` — see `backup-manager/src/main/java/com/openmc/backupmanager/service/BackupService.java`. Proxying a full-directory tar through an HTTP API on the wrapper would add complexity (streaming, timeouts, partial-failure handling) without removing the need for shared storage, since the wrapper itself still has to read every file to stream it.
+
+Given that, making `minecraft-wrapper` the sole PVC owner (sidecar/init-container pattern) was evaluated and rejected for now — it doesn't eliminate the shared-storage requirement, it just relocates it behind an API that would need to support arbitrary file listing, upload, and bulk-download. RWX StorageClasses solve the actual problem (multi-node scheduling) directly and are already supported by the existing `accessMode` value.
+
+**Priority:** Low — the current affinity rules work for typical 2-node clusters; RWX is documented as the option for larger or more constrained environments.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds a **Multi-Node Scheduling & RWX StorageClasses** section to the README documenting that `persistence.*.accessMode` can already be set to `ReadWriteMany` (no code change needed) to remove the mcserver PVC's pod-affinity co-location requirement, with NFS / AWS EFS / Longhorn listed as concrete RWX-capable options.
- Updates `docs/KUBERNETES_IMPROVEMENTS.md` item 6 with the evaluation the issue asked for: whether `webapp` and `backup-manager` truly need direct filesystem access to `/mcserver`.
  - `webapp`'s `WorldService` / `PluginService` list, upload, and delete files directly (world dirs, plugin jars).
  - `backup-manager`'s `BackupService` runs `tar` directly against the whole `/mcserver` directory.
  - Conclusion: making `minecraft-wrapper` the sole PVC owner would only relocate the shared-storage need behind a much larger wrapper API surface (streaming file transfer/listing/bulk-download), not eliminate it — so RWX StorageClasses are documented as the practical fix for multi-node scheduling instead.
- No Helm template, `values.yaml`, or Docker Compose changes: `accessMode` was already a configurable Helm value, and this constraint is Kubernetes-only (Docker Compose is single-host, so there's no equivalent to document there).

Closes #147

## Test plan
- [x] Documentation-only change — no `helm/omcsi/templates/`, `values.yaml`, `compose.yml`, or application code touched.
- [x] Verified in source that `persistence.mcserver.accessMode` (and the other three PVCs) is already a plain, overridable Helm value (`helm/omcsi/values.yaml`), so the documented `--set persistence.mcserver.accessMode=ReadWriteMany` example works today.
- [x] Verified the direct-filesystem-access claims by reading `WorldService.java`, `PluginService.java`, and `BackupService.java`.
- [ ] CI (docs-only — no Helm/Gradle jobs expected to be affected, but this PR could not run `helm lint`/`helm unittest` locally in this sandbox session since the `helm` binary requires an approval this headless session has no human available to grant; CI is the real verification anchor here)

<!-- gardener-tend-dispatch -->


---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._