### PR TITLE
fix: restore Docker Compose env parity and cover all Gradle modules in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,36 @@ jobs:
         ./gradlew test
         echo "✓ All tests passed"
         
+    - name: Build alert-manager module
+      run: |
+        echo "🔔 Building alert-manager module..."
+        cd alert-manager
+        ./gradlew build
+        echo "✓ Alert manager built successfully"
+        ls -lh build/libs/
+
+    - name: Run alert-manager tests
+      run: |
+        echo "🧪 Running alert-manager tests..."
+        cd alert-manager
+        ./gradlew test
+        echo "✓ All tests passed"
+
+    - name: Build backup-manager module
+      run: |
+        echo "💾 Building backup-manager module..."
+        cd backup-manager
+        ./gradlew build
+        echo "✓ Backup manager built successfully"
+        ls -lh build/libs/
+
+    - name: Run backup-manager tests
+      run: |
+        echo "🧪 Running backup-manager tests..."
+        cd backup-manager
+        ./gradlew test
+        echo "✓ All tests passed"
+
     - name: Validate documentation
       run: |
         echo "📚 Validating documentation..."

--- a/CI-DOCUMENTATION.md
+++ b/CI-DOCUMENTATION.md
@@ -41,9 +41,11 @@ for each Spring Boot module that has its own Gradle project:
 - `web-app`
 - `minecraft-wrapper`
 - `agent-manager`
+- `alert-manager`
+- `backup-manager`
 
-(Other modules — `alert-manager`, `backup-manager` — are exercised indirectly
-via the Helm tests and the end-to-end server run.)
+`scripts/ci-local.sh` runs `./gradlew test` for this same list — keep the two
+in sync when a module is added or removed.
 
 #### Documentation Validation
 - Confirms `README.md` exists and contains the expected H1
@@ -121,6 +123,9 @@ You can run the same validation checks locally using:
 ```
 
 This script mirrors the CI pipeline checks and helps catch issues before submitting changes.
+It validates the compose file against a `mktemp` copy of `sample.env` rather than your
+`.env`, so your real credentials are left untouched. Because it now runs the test suite
+for all five Gradle modules, expect it to take several minutes on a cold Gradle cache.
 
 ## What Gets Checked
 
@@ -128,7 +133,7 @@ This script mirrors the CI pipeline checks and helps catch issues before submitt
 - Shell script syntax (`bash -n`)
 - ShellCheck linting compliance
 - Java module compilation and unit tests for `web-app`,
-  `minecraft-wrapper`, and `agent-manager`
+  `minecraft-wrapper`, `agent-manager`, `alert-manager`, and `backup-manager`
 
 ### ✅ Configuration Integrity
 - Dockerfile parses and the `base` stage builds

--- a/compose.yml
+++ b/compose.yml
@@ -49,7 +49,13 @@ services:
       - ALERTS_SERVER_STOP=${ALERTS_SERVER_STOP:-true}
       - ALERTS_SERVER_CRASH=${ALERTS_SERVER_CRASH:-true}
       - ALERTS_CONFIG_WARNING=${ALERTS_CONFIG_WARNING:-false}
+      - ALERTS_PLUGIN_DEPLOY=${ALERTS_PLUGIN_DEPLOY:-true}
       - ALERTS_WORLD_UPLOAD=${ALERTS_WORLD_UPLOAD:-true}
+      # Diagnostic log access (consumed by ServerController's GET /api/server/logs).
+      # Must be enabled here *and* via DIAGNOSTICS_LOGS_ENABLED on agent-manager
+      # for the agent to include log snippets in diagnostics.
+      - LOGS_DIAGNOSTIC_ENABLED=${LOGS_DIAGNOSTIC_ENABLED:-false}
+      - LOGS_DIAGNOSTIC_MAX_LINES=${LOGS_DIAGNOSTIC_MAX_LINES:-100}
       # Plugin deployment CI/CD configuration
       - DEPLOY_AUTH_TOKEN=${DEPLOY_AUTH_TOKEN:-}
       - PLUGINS_DIRECTORY=${PLUGINS_DIRECTORY:-/mcserver/plugins}
@@ -214,6 +220,11 @@ services:
       - ALERT_MANAGER_URL=${ALERT_MANAGER_URL:-http://alert-manager:8090/api/alerts}
       - BACKUP_MANAGER_URL=${BACKUP_MANAGER_URL:-http://backup-manager:8091}
       - DIAGNOSTICS_WEBAPP_ENABLED=${DIAGNOSTICS_WEBAPP_ENABLED:-false}
+      # Diagnostic log inclusion. Requires LOGS_DIAGNOSTIC_ENABLED=true on
+      # minecraft-wrapper as well; logs are IP-anonymized unless explicitly disabled.
+      - DIAGNOSTICS_LOGS_ENABLED=${DIAGNOSTICS_LOGS_ENABLED:-false}
+      - DIAGNOSTICS_LOGS_MAX_LINES=${DIAGNOSTICS_LOGS_MAX_LINES:-500}
+      - DIAGNOSTICS_LOGS_ANONYMIZE=${DIAGNOSTICS_LOGS_ANONYMIZE:-true}
       - WEBAPP_URL=${WEBAPP_URL:-http://webapp:8080}
 
 volumes:

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -16,12 +16,15 @@ bash -n resources/post-create.sh
 echo "✅ Shell script syntax validation passed"
 
 echo "🐳 Checking Docker configuration..."
-# Create a temporary .env file for validation
-cp sample.env .env
-sed -i 's/YOUR_UUID_HERE/test-uuid/g' .env
-sed -i 's/YOUR_USERNAME_HERE/testuser/g' .env
-docker compose config > /dev/null
-rm .env
+# Validate against a throwaway env file rather than the repo's .env — that file
+# is gitignored and holds real credentials (RCON/admin passwords, Discord
+# webhook, Anthropic API key), so it must never be overwritten or deleted here.
+CI_ENV_FILE="$(mktemp)"
+trap 'rm -f "${CI_ENV_FILE}"' EXIT
+sed -e 's/YOUR_UUID_HERE/test-uuid/g' \
+    -e 's/YOUR_USERNAME_HERE/testuser/g' \
+    sample.env > "${CI_ENV_FILE}"
+docker compose --env-file "${CI_ENV_FILE}" config > /dev/null
 echo "✅ Docker Compose validation passed"
 
 echo "⚙️ Checking environment configuration..."
@@ -45,10 +48,12 @@ test -x trigger-backup.sh
 test -x resources/post-create.sh
 echo "✅ File permissions validation passed"
 
-echo "🧪 Running minecraft-wrapper tests..."
-cd minecraft-wrapper
-./gradlew test --no-daemon
-cd ..
-echo "✅ Minecraft wrapper tests passed"
+# Every Gradle module the CI pipeline tests. Keep this list in sync with the
+# "Run <module> tests" steps in .github/workflows/ci.yml.
+for module in web-app minecraft-wrapper agent-manager alert-manager backup-manager; do
+    echo "🧪 Running ${module} tests..."
+    (cd "${module}" && ./gradlew test --no-daemon)
+    echo "✅ ${module} tests passed"
+done
 
 echo "🎉 All local CI checks passed!"


### PR DESCRIPTION
## Summary

Three related config/CI-plumbing fixes, each verified against source before changing anything.

**1. Docker Compose was dropping six documented environment variables (#199)**

`ALERTS_PLUGIN_DEPLOY`, `LOGS_DIAGNOSTIC_ENABLED`, `LOGS_DIAGNOSTIC_MAX_LINES` (minecraft-wrapper) and `DIAGNOSTICS_LOGS_ENABLED`, `DIAGNOSTICS_LOGS_MAX_LINES`, `DIAGNOSTICS_LOGS_ANONYMIZE` (agent-manager) are documented in `sample.env` and wired through `helm/omcsi/values.yaml` + templates, but were absent from the `environment:` blocks in `compose.yml`. Setting them in `.env` did nothing.

The practical effect: the agent-manager's diagnostic log-inclusion feature requires `LOGS_DIAGNOSTIC_ENABLED=true` on the wrapper **and** `DIAGNOSTICS_LOGS_ENABLED=true` on the agent — neither reached its container, so the feature was unreachable on Docker Compose while working fine on Kubernetes. Defaults added here match `sample.env` and `values.yaml` exactly, so behaviour is unchanged for anyone not setting them.

**2. `alert-manager` and `backup-manager` were never built or tested in CI (#200)**

`.github/workflows/ci.yml` built and tested `web-app`, `minecraft-wrapper`, and `agent-manager` only. The other two modules have 8 and 3 test classes respectively, none of which ran on a pull request — they were only compiled by `docker-publish.yml`, which triggers on push to `main`, i.e. after merge. Recent PRs (#193, #184) changed both modules directly.

**3. `scripts/ci-local.sh` destroyed the developer's `.env` (#201)**

The script did `cp sample.env .env` → … → `rm .env`, unconditionally clobbering the gitignored file holding real RCON/admin passwords, Discord webhook, and Anthropic API key. With `set -e`, a `docker compose config` failure also skipped the `rm`, leaving a sample-derived `.env` (`ADMIN_PASSWORD=admin`, `RCON_PASSWORD=minecraft`) that `./up.sh` would happily deploy. Now validated against a `mktemp` file via `docker compose --env-file`, cleaned up by a `trap ... EXIT` so it survives both success and failure. The script also now runs tests for all five Gradle modules, matching CI.

`CI-DOCUMENTATION.md` is updated for the new module list and the local-testing behaviour change.

## Test plan

- [x] `compose.yml` and `.github/workflows/ci.yml` parse as valid YAML
- [x] Programmatic parity check: no env key remains in `helm/omcsi/values.yaml` but missing from `compose.yml` for any service, except `ALERTS_UPGRADE_{START,COMPLETE,FAILURE}` (read only by `upgrade.sh` on the Docker host — see note below) and `backupManager.SOURCE_DIRECTORY` / `SPRING_TASK_SCHEDULING_ENABLED` (Compose relies on the `/mcserver` default, which matches its mount)
- [x] Programmatic check that `ci.yml`'s `validate` job now has a `./gradlew build` **and** `./gradlew test` step for all five modules
- [x] `cd alert-manager && ./gradlew build && ./gradlew test` — BUILD SUCCESSFUL
- [x] `cd backup-manager && ./gradlew build && ./gradlew test` — BUILD SUCCESSFUL
- [x] `sample.env` already documents all six variables; no new knobs introduced, so no `values.yaml` or `sample.env` change is required
- [x] No Helm template touched, so `helm lint` / `helm unittest` behaviour is unchanged
- [ ] `shellcheck scripts/ci-local.sh`, `docker compose config`, and `helm lint`/`helm unittest` could not be run in this environment (no `docker`; the `shellcheck`/`helm` binaries were not executable in the sandbox). CI covers all three.

### Both-targets checklist (per `CLAUDE.md`)

- [x] `compose.yml` updated — this is the Docker side of an existing Kubernetes-only capability
- [x] `sample.env` — already complete, verified
- [x] Helm chart — already correct, verified; no change needed
- [x] NetworkPolicies — no new inter-service traffic path introduced
- [x] Docker and Kubernetes now expose the same knobs for both affected services

## Note for a follow-up

`ALERTS_UPGRADE_START` / `_COMPLETE` / `_FAILURE` are set on the minecraft-wrapper **pod** by the Helm chart, but the only consumer is `upgrade.sh`, a Docker-host script that sources `.env` directly. Nothing in the wrapper reads them, so they are inert on Kubernetes. This is the same class of dead knob as #202 and is left out of scope here.

Closes #199
Closes #200
Closes #201

<!-- gardener-tend-dispatch -->



---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._