### PR TITLE
fix(helm): drop inert ALERTS_UPGRADE_* and SPRING_TASK_SCHEDULING_ENABLED env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -806,7 +806,7 @@ docker compose --env-file .env.dev2 up -d --build
 
 - `BACKUP_CONTAINER_NAME`: Backup manager container name (default: `open-mc-backup-manager`)
 - `BACKUP_MAX_SIZE_MB`: Maximum size of backups directory in MB (default: `10240` = 10GB)
-- `BACKUP_SCHEDULE`: Cron expression for backup schedule (default: `0 0 2 * * ?` = 2 AM daily)
+- `BACKUP_SCHEDULE`: Cron expression for backup schedule (default: `0 0 2 * * ?` = 2 AM daily). Set to `-` to disable scheduled backups entirely; manual backups via `POST /api/backups/trigger` and `trigger-backup.sh` keep working.
 
 See [backup-manager/README.md](backup-manager/README.md) for detailed cron expression examples and configuration.
 
@@ -823,10 +823,14 @@ See [backup-manager/README.md](backup-manager/README.md) for detailed cron expre
 - `ALERTS_SERVER_CRASH`: Alert when server crashes unexpectedly (default: `true`)
 - `ALERTS_BACKUP_SUCCESS`: Alert when backup completes successfully (default: `true`)
 - `ALERTS_BACKUP_FAILURE`: Alert when backup fails (default: `true`)
+- `ALERTS_CONFIG_WARNING`: Alert when server starts with configuration warnings (default: `false`)
+
+The following three toggles are read by `upgrade.sh`, which runs on the Docker host and drives
+`docker compose` directly. They apply to the **Docker Compose deployment only** and have no
+Kubernetes equivalent, so the Helm chart does not expose them:
 - `ALERTS_UPGRADE_START`: Alert when upgrade process begins (default: `true`)
 - `ALERTS_UPGRADE_COMPLETE`: Alert when upgrade completes successfully (default: `true`)
 - `ALERTS_UPGRADE_FAILURE`: Alert when upgrade fails (default: `true`)
-- `ALERTS_CONFIG_WARNING`: Alert when server starts with configuration warnings (default: `false`)
 
 To enable Discord notifications:
 1. Create a webhook in your Discord server (Server Settings → Integrations → Webhooks)

--- a/README.md
+++ b/README.md
@@ -823,6 +823,8 @@ See [backup-manager/README.md](backup-manager/README.md) for detailed cron expre
 - `ALERTS_SERVER_CRASH`: Alert when server crashes unexpectedly (default: `true`)
 - `ALERTS_BACKUP_SUCCESS`: Alert when backup completes successfully (default: `true`)
 - `ALERTS_BACKUP_FAILURE`: Alert when backup fails (default: `true`)
+- `ALERTS_PLUGIN_DEPLOY`: Alert on plugin deployment success or failure (default: `true`)
+- `ALERTS_WORLD_UPLOAD`: Alert on world upload success or failure (default: `true`)
 - `ALERTS_CONFIG_WARNING`: Alert when server starts with configuration warnings (default: `false`)
 
 The following three toggles are read by `upgrade.sh`, which runs on the Docker host and drives

--- a/backup-manager/README.md
+++ b/backup-manager/README.md
@@ -19,7 +19,7 @@ The following environment variables can be configured in `.env`:
 
 - `BACKUP_CONTAINER_NAME`: Container name (default: `open-mc-backup-manager`)
 - `BACKUP_MAX_SIZE_MB`: Maximum size of backups directory in MB (default: `10240` = 10GB)
-- `BACKUP_SCHEDULE`: Cron expression for backup schedule (default: `0 0 2 * * ?` = 2 AM daily)
+- `BACKUP_SCHEDULE`: Cron expression for backup schedule (default: `0 0 2 * * ?` = 2 AM daily). Set to `-` (Spring's `Scheduled.CRON_DISABLED` marker) to disable scheduled backups; the manual `POST /api/backups/trigger` endpoint is unaffected.
 - `SOURCE_DIRECTORY`: Path to the mounted Minecraft server data directory (default: `/mcserver`)
 - `ALERTS_BACKUP_SUCCESS`: Enable alerts for successful backups (default: `true`)
 - `ALERTS_BACKUP_FAILURE`: Enable alerts for failed backups (default: `true`)

--- a/backup-manager/src/main/resources/application.properties
+++ b/backup-manager/src/main/resources/application.properties
@@ -11,6 +11,8 @@ backup.max.size.mb=${BACKUP_MAX_SIZE_MB:10240}
 # Backup schedule (cron expression)
 # Default: 0 0 2 * * ? (2 AM every day)
 # Can be overridden with BACKUP_SCHEDULE environment variable
+# Set to "-" (Spring's Scheduled.CRON_DISABLED) to disable scheduled backups;
+# @EnableScheduling itself cannot be switched off by a property.
 backup.schedule=${BACKUP_SCHEDULE:0 0 2 * * ?}
 
 # Directory where the Minecraft server data is mounted

--- a/backup-manager/src/test/java/com/openmc/backupmanager/service/BackupScheduleTest.java
+++ b/backup-manager/src/test/java/com/openmc/backupmanager/service/BackupScheduleTest.java
@@ -1,0 +1,84 @@
+package com.openmc.backupmanager.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.scheduling.config.ScheduledTask;
+import org.springframework.scheduling.config.ScheduledTaskHolder;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies how {@code backup.schedule} controls registration of the
+ * {@link BackupService#performScheduledBackup()} cron task.
+ *
+ * <p>Spring treats the cron value {@code "-"} ({@code Scheduled.CRON_DISABLED}) as
+ * "never run", which is the only supported way to switch scheduled backups off —
+ * {@code @EnableScheduling} on the application class cannot be disabled by a property.
+ */
+@DisplayName("Backup schedule configuration")
+class BackupScheduleTest {
+
+    private static boolean hasScheduledBackupTask(ScheduledTaskHolder taskHolder) {
+        Set<ScheduledTask> tasks = taskHolder.getScheduledTasks();
+        return tasks.stream()
+                .map(task -> task.getTask().getRunnable().toString())
+                .anyMatch(description -> description.contains("performScheduledBackup"));
+    }
+
+    @Nested
+    @SpringBootTest
+    @TestPropertySource(properties = {
+        "backup.directory=/tmp/test-backups",
+        "source.directory=/tmp/test-mcserver",
+        "backup.schedule=0 0 2 * * ?"
+    })
+    @DisplayName("with a cron expression")
+    class WithCronExpression {
+
+        @Autowired
+        private ScheduledTaskHolder taskHolder;
+
+        @MockBean
+        private RestTemplate restTemplate;
+
+        @Test
+        @DisplayName("Should register the scheduled backup task")
+        void shouldRegisterScheduledBackupTask() {
+            assertTrue(hasScheduledBackupTask(taskHolder),
+                    "performScheduledBackup should be registered when backup.schedule is a cron expression");
+        }
+    }
+
+    @Nested
+    @SpringBootTest
+    @TestPropertySource(properties = {
+        "backup.directory=/tmp/test-backups",
+        "source.directory=/tmp/test-mcserver",
+        "backup.schedule=-"
+    })
+    @DisplayName("with the disabled marker \"-\"")
+    class WithDisabledMarker {
+
+        @Autowired
+        private ScheduledTaskHolder taskHolder;
+
+        @MockBean
+        private RestTemplate restTemplate;
+
+        @Test
+        @DisplayName("Should not register the scheduled backup task")
+        void shouldNotRegisterScheduledBackupTask() {
+            assertFalse(hasScheduledBackupTask(taskHolder),
+                    "performScheduledBackup should not be registered when backup.schedule is \"-\"");
+        }
+    }
+}

--- a/docs/KUBERNETES_IMPROVEMENTS.md
+++ b/docs/KUBERNETES_IMPROVEMENTS.md
@@ -18,6 +18,8 @@ This document captures issues, limitations, and improvement opportunities surfac
 - `helm/omcsi/values.yaml`: enabled scheduled backups (`SPRING_TASK_SCHEDULING_ENABLED: "true"`, `BACKUP_SCHEDULE: "0 0 2 * * ?"`), enabled alerts, replaced `VOLUME_NAME` with `SOURCE_DIRECTORY`.
 - `helm/omcsi/templates/backup-manager.yaml`: replaced `VOLUME_NAME` env entry with `SOURCE_DIRECTORY`.
 
+**Follow-up:** `SPRING_TASK_SCHEDULING_ENABLED` was later removed — `spring.task.scheduling.enabled` is not a Spring Boot property, so the knob never disabled anything. Scheduled backups are switched off by setting `BACKUP_SCHEDULE` to `-` (Spring's `Scheduled.CRON_DISABLED` marker) instead.
+
 ---
 
 ## 2. Health Probes — Missing for Several Services ✅ Resolved

--- a/helm/omcsi/templates/backup-manager.yaml
+++ b/helm/omcsi/templates/backup-manager.yaml
@@ -47,8 +47,6 @@ spec:
             - name: BACKUP_SCHEDULE
               value: {{ .Values.backupManager.env.BACKUP_SCHEDULE | quote }}
             {{- end }}
-            - name: SPRING_TASK_SCHEDULING_ENABLED
-              value: {{ .Values.backupManager.env.SPRING_TASK_SCHEDULING_ENABLED | default "true" | quote }}
             - name: SOURCE_DIRECTORY
               value: {{ .Values.backupManager.env.SOURCE_DIRECTORY | default "/mcserver" | quote }}
             - name: ALERTS_BACKUP_SUCCESS

--- a/helm/omcsi/templates/minecraft-wrapper.yaml
+++ b/helm/omcsi/templates/minecraft-wrapper.yaml
@@ -94,12 +94,9 @@ spec:
               value: {{ .Values.minecraftWrapper.env.ALERTS_PLUGIN_DEPLOY | quote }}
             - name: ALERTS_WORLD_UPLOAD
               value: {{ .Values.minecraftWrapper.env.ALERTS_WORLD_UPLOAD | quote }}
-            - name: ALERTS_UPGRADE_START
-              value: {{ .Values.minecraftWrapper.env.ALERTS_UPGRADE_START | quote }}
-            - name: ALERTS_UPGRADE_COMPLETE
-              value: {{ .Values.minecraftWrapper.env.ALERTS_UPGRADE_COMPLETE | quote }}
-            - name: ALERTS_UPGRADE_FAILURE
-              value: {{ .Values.minecraftWrapper.env.ALERTS_UPGRADE_FAILURE | quote }}
+            # ALERTS_UPGRADE_START/COMPLETE/FAILURE are intentionally absent: their only
+            # consumer is upgrade.sh, a host-side script that drives `docker compose`
+            # directly, so they are Docker Compose-only and inert inside this container.
             - name: DEPLOY_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/helm/omcsi/tests/backup_manager_test.yaml
+++ b/helm/omcsi/tests/backup_manager_test.yaml
@@ -98,3 +98,27 @@ tests:
             name: BACKUP_SCHEDULE
           any: true
         documentIndex: 0
+
+  # "-" is Spring's Scheduled.CRON_DISABLED marker — the only supported way to turn
+  # the scheduled backup off, since @EnableScheduling cannot be disabled by a property.
+  - it: backup schedule env var passes through the "-" disabled marker
+    set:
+      backupManager.env.BACKUP_SCHEDULE: "-"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BACKUP_SCHEDULE
+            value: "-"
+        documentIndex: 0
+
+  # SPRING_TASK_SCHEDULING_ENABLED is not a Spring Boot property; it never disabled
+  # anything, so it must not be rendered as though it were a supported knob.
+  - it: does not render the non-functional SPRING_TASK_SCHEDULING_ENABLED knob
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SPRING_TASK_SCHEDULING_ENABLED
+          any: true
+        documentIndex: 0

--- a/helm/omcsi/tests/minecraft_wrapper_test.yaml
+++ b/helm/omcsi/tests/minecraft_wrapper_test.yaml
@@ -190,3 +190,41 @@ tests:
           path: spec.template.spec.volumes[0].persistentVolumeClaim.claimName
           value: RELEASE-NAME-omcsi-mcserver
         documentIndex: 0
+
+  # ALERTS_UPGRADE_* are read by upgrade.sh on the Docker host, never inside this
+  # container, so rendering them here would be inert config that looks supported.
+  - it: does not render the Compose-only ALERTS_UPGRADE_* toggles
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ALERTS_UPGRADE_START
+          any: true
+        documentIndex: 0
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ALERTS_UPGRADE_COMPLETE
+          any: true
+        documentIndex: 0
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ALERTS_UPGRADE_FAILURE
+          any: true
+        documentIndex: 0
+
+  - it: still renders the alert toggles the container actually reads
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ALERTS_SERVER_START
+            value: "true"
+        documentIndex: 0
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ALERTS_CONFIG_WARNING
+            value: "false"
+        documentIndex: 0

--- a/helm/omcsi/values.yaml
+++ b/helm/omcsi/values.yaml
@@ -78,9 +78,9 @@ minecraftWrapper:
     ALERTS_CONFIG_WARNING: "false"
     ALERTS_PLUGIN_DEPLOY: "true"
     ALERTS_WORLD_UPLOAD: "true"
-    ALERTS_UPGRADE_START: "true"
-    ALERTS_UPGRADE_COMPLETE: "true"
-    ALERTS_UPGRADE_FAILURE: "true"
+    # NOTE: ALERTS_UPGRADE_START/COMPLETE/FAILURE are deliberately not listed here.
+    # They are read by upgrade.sh on the Docker host, never inside the container,
+    # so they have no meaning for the Kubernetes deployment.
     # Diagnostic log access
     LOGS_DIAGNOSTIC_ENABLED: "false"
     LOGS_DIAGNOSTIC_MAX_LINES: "100"
@@ -214,8 +214,9 @@ backupManager:
     BACKUP_MAX_SIZE_MB: "10240"
     # Cron expression: seconds minutes hours day-of-month month day-of-week
     # Default: 2:00 AM every day (server/container local time)
+    # Set to "-" to disable scheduled backups entirely; the manual
+    # POST /api/backups/trigger endpoint keeps working either way.
     BACKUP_SCHEDULE: "0 0 2 * * ?"
-    SPRING_TASK_SCHEDULING_ENABLED: "true"
     SOURCE_DIRECTORY: "/mcserver"
     ALERTS_BACKUP_SUCCESS: "true"
     ALERTS_BACKUP_FAILURE: "true"

--- a/sample.env
+++ b/sample.env
@@ -115,6 +115,7 @@ BACKUP_PORT=8091
 # Maximum size of the backups directory in MB (default: 10GB)
 BACKUP_MAX_SIZE_MB=10240
 # Backup schedule (cron expression, default: 0 0 2 * * ? = 2 AM every day)
+# Set to - to disable scheduled backups; POST /api/backups/trigger still works.
 BACKUP_SCHEDULE=0 0 2 * * ?
 
 # Alert Manager Configuration
@@ -184,6 +185,7 @@ ALERTS_WORLD_UPLOAD=true
 ALERTS_BACKUP_SUCCESS=true
 ALERTS_BACKUP_FAILURE=true
 # Upgrade alerts
+# Read by upgrade.sh on the Docker host — Docker Compose only, no Kubernetes equivalent.
 ALERTS_UPGRADE_START=true
 ALERTS_UPGRADE_COMPLETE=true
 ALERTS_UPGRADE_FAILURE=true


### PR DESCRIPTION
## Summary

Removes two Helm-chart env vars that render into pod specs but have no consumer, and documents the mechanism that actually works in place of one of them.

**`ALERTS_UPGRADE_START` / `ALERTS_UPGRADE_COMPLETE` / `ALERTS_UPGRADE_FAILURE` (minecraft-wrapper)** — the only consumers are `upgrade.sh:159`, `upgrade.sh:238` and `upgrade.sh:268`. That script `cd`s to the repo root, reads toggles from the host `.env`, and drives `docker compose` directly, so it is Docker-Compose-only by construction — which is exactly why `compose.yml` never passed these three into the container. The chart passed them anyway, so they looked like supported Kubernetes knobs while doing nothing (and rolled the Deployment when changed). Removed from the template and `values.yaml`; `README.md` and `sample.env` now say they are Compose-only.

**`SPRING_TASK_SCHEDULING_ENABLED` (backup-manager)** — relaxed binding maps this to `spring.task.scheduling.enabled`, which is not a Spring Boot property. `TaskSchedulingProperties` has `pool.*`, `shutdown.*`, `simple.*` and `thread-name-prefix`, but no `enabled`; scheduling comes from `@EnableScheduling` on `BackupManagerApplication`, which no property can switch off. So `SPRING_TASK_SCHEDULING_ENABLED: "false"` did **not** stop the nightly backup — worse than dead config, since it promised something it never did. It was added in b966613 to "truly disable scheduling" when backups were known-broken on Kubernetes; 10a8e5e fixed backups and flipped the default to `"true"`, leaving the non-functional knob behind.

Its replacement is the mechanism Spring actually supports: `@Scheduled` treats the cron value `-` (`Scheduled.CRON_DISABLED`) as "never run". `BACKUP_SCHEDULE=-` disables the scheduled backup on **both** deployment targets while leaving `POST /api/backups/trigger` (and `trigger-backup.sh`) working. Documented in `values.yaml`, `sample.env`, `README.md`, `backup-manager/README.md` and `application.properties`.

Both are pure cleanups of inert config: neither var had any runtime effect before this change, so nothing can regress.

## Test plan

- [x] `BackupScheduleTest` (new) — runtime proof rather than a claim, via `ScheduledTaskHolder`: `performScheduledBackup` **is** registered with `backup.schedule=0 0 2 * * ?`, and **is not** registered with `backup.schedule=-`. The positive case is what keeps the negative case from passing vacuously.
- [x] `cd backup-manager && ./gradlew build --no-daemon` — BUILD SUCCESSFUL, full suite green.
- [x] Both edited Helm templates re-parsed as YAML after template-action stripping: `minecraft-wrapper.yaml` renders 3 documents / 28 env vars with no `ALERTS_UPGRADE_*`; `backup-manager.yaml` renders 2 documents / 7 env vars with no `SPRING_TASK_SCHEDULING_ENABLED`; every other env var is intact.
- [x] `values.yaml` and both edited `helm/omcsi/tests/*.yaml` files parse cleanly (17 and 9 cases).
- [x] New `helm unittest` cases pin the removals — `notContains` for all four var names, plus positive assertions that `ALERTS_SERVER_START` / `ALERTS_CONFIG_WARNING` still render and that `BACKUP_SCHEDULE: "-"` passes through.
- [x] Checked `terraform/`, `.github/`, `SELF-HOSTING.md`, `UPGRADE-GUIDE.md` and `CLAUDE.md` for references to the removed knobs — only `docs/KUBERNETES_IMPROVEMENTS.md` mentioned one, in a historical "changes made" list, so a follow-up note was appended rather than rewriting the record.

### Docker / Kubernetes parity

- [x] `compose.yml` — no change needed; it already, correctly, did not pass any of these four vars to a container.
- [x] `sample.env` — annotated `ALERTS_UPGRADE_*` as Compose-only and documented `BACKUP_SCHEDULE=-`.
- [x] Helm chart — templates and `values.yaml` updated for both services.
- [x] NetworkPolicies — no new inter-service traffic path, no change required.
- [x] Both targets verified for the surviving knob: `BACKUP_SCHEDULE=-` flows through `compose.yml`'s `BACKUP_SCHEDULE=${BACKUP_SCHEDULE:-0 0 2 * * ?}` and through the chart's conditional `BACKUP_SCHEDULE` env entry into the same `backup.schedule` property.

**Not run locally:** `helm lint`, `helm unittest` and `docker compose config` — the `helm` CLI and Docker are both unavailable in this environment. CI covers all three (`ci.yml:163`, `ci.yml:188`, plus the kind-based `helm-deploy-test`), so please treat those jobs as the gate on the chart changes. Only `backup-manager` was touched on the Gradle side; no shell scripts or Terraform files were modified.

Closes #204
Closes #205

<!-- gardener-tend-dispatch -->



---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._