### PR TITLE
fix(web-app): surface minecraft-wrapper error details on the dashboard

### DIFF
--- a/minecraft-wrapper/src/test/java/com/openmc/minecraftwrapper/util/BearerTokenAuthenticatorTest.java
+++ b/minecraft-wrapper/src/test/java/com/openmc/minecraftwrapper/util/BearerTokenAuthenticatorTest.java
@@ -1,0 +1,84 @@
+package com.openmc.minecraftwrapper.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("BearerTokenAuthenticator Tests")
+class BearerTokenAuthenticatorTest {
+
+    private static final String TOKEN = "s3cret-deploy-token";
+    private static final String ENDPOINT = "plugin deploy";
+
+    @Test
+    @DisplayName("Should authorize a header carrying the exact configured token")
+    void shouldAuthorizeExactMatch() {
+        assertTrue(BearerTokenAuthenticator.isAuthorized("Bearer " + TOKEN, TOKEN, ENDPOINT));
+    }
+
+    @Test
+    @DisplayName("Should fail closed when the configured token is null")
+    void shouldRejectWhenConfiguredTokenIsNull() {
+        assertFalse(BearerTokenAuthenticator.isAuthorized("Bearer " + TOKEN, null, ENDPOINT));
+        assertFalse(BearerTokenAuthenticator.isAuthorized("Bearer ", null, ENDPOINT));
+        assertFalse(BearerTokenAuthenticator.isAuthorized(null, null, ENDPOINT));
+    }
+
+    @Test
+    @DisplayName("Should fail closed when the configured token is empty or whitespace")
+    void shouldRejectWhenConfiguredTokenIsBlank() {
+        assertFalse(BearerTokenAuthenticator.isAuthorized("Bearer " + TOKEN, "", ENDPOINT));
+        assertFalse(BearerTokenAuthenticator.isAuthorized("Bearer " + TOKEN, "   ", ENDPOINT));
+        assertFalse(BearerTokenAuthenticator.isAuthorized("Bearer " + TOKEN, "\t", ENDPOINT));
+        // An unconfigured server must reject even a request presenting the empty token itself
+        assertFalse(BearerTokenAuthenticator.isAuthorized("Bearer ", "", ENDPOINT));
+    }
+
+    @Test
+    @DisplayName("Should reject a request with no Authorization header")
+    void shouldRejectMissingHeader() {
+        assertFalse(BearerTokenAuthenticator.isAuthorized(null, TOKEN, ENDPOINT));
+    }
+
+    @Test
+    @DisplayName("Should reject a header that does not use the 'Bearer ' prefix")
+    void shouldRejectHeaderWithoutBearerPrefix() {
+        assertFalse(BearerTokenAuthenticator.isAuthorized(TOKEN, TOKEN, ENDPOINT));
+        assertFalse(BearerTokenAuthenticator.isAuthorized("bearer " + TOKEN, TOKEN, ENDPOINT));
+        assertFalse(BearerTokenAuthenticator.isAuthorized("Bearer" + TOKEN, TOKEN, ENDPOINT));
+        assertFalse(BearerTokenAuthenticator.isAuthorized("Basic " + TOKEN, TOKEN, ENDPOINT));
+        assertFalse(BearerTokenAuthenticator.isAuthorized("Token " + TOKEN, TOKEN, ENDPOINT));
+        assertFalse(BearerTokenAuthenticator.isAuthorized("", TOKEN, ENDPOINT));
+    }
+
+    @Test
+    @DisplayName("Should reject an empty token after the Bearer prefix")
+    void shouldRejectEmptyTokenAfterPrefix() {
+        assertFalse(BearerTokenAuthenticator.isAuthorized("Bearer ", TOKEN, ENDPOINT));
+    }
+
+    @Test
+    @DisplayName("Should reject a token that is only a prefix or suffix of the configured one")
+    void shouldRejectPartialToken() {
+        assertFalse(BearerTokenAuthenticator.isAuthorized("Bearer s3cret", TOKEN, ENDPOINT));
+        assertFalse(BearerTokenAuthenticator.isAuthorized("Bearer deploy-token", TOKEN, ENDPOINT));
+        assertFalse(BearerTokenAuthenticator.isAuthorized("Bearer s3cret-deploy-toke", TOKEN, ENDPOINT));
+        assertFalse(BearerTokenAuthenticator.isAuthorized("Bearer s3cret-deploy-tokens", TOKEN, ENDPOINT));
+    }
+
+    @Test
+    @DisplayName("Should reject a token differing only in case")
+    void shouldRejectTokenDifferingInCase() {
+        assertFalse(BearerTokenAuthenticator.isAuthorized("Bearer S3CRET-DEPLOY-TOKEN", TOKEN, ENDPOINT));
+    }
+
+    @Test
+    @DisplayName("Should not trim the configured token when comparing")
+    void shouldNotTrimConfiguredTokenWhenComparing() {
+        // The blank check trims, but the comparison must use the configured value verbatim.
+        assertTrue(BearerTokenAuthenticator.isAuthorized("Bearer  padded ", " padded ", ENDPOINT));
+        assertFalse(BearerTokenAuthenticator.isAuthorized("Bearer padded", " padded ", ENDPOINT));
+    }
+}

--- a/web-app/src/main/java/com/openmc/webapp/controller/ServerController.java
+++ b/web-app/src/main/java/com/openmc/webapp/controller/ServerController.java
@@ -358,16 +358,16 @@ public class ServerController {
             return WorldOperationResponse.error("World upload is not configured on this server");
         }
 
-        boolean success = minecraftWrapperService.uploadWorld(file, deployAuthToken);
+        var result = minecraftWrapperService.uploadWorld(file, deployAuthToken);
 
-        if (success) {
+        if (result.success()) {
             alertNotificationService.sendInfoAlert(
                 "World Uploaded Successfully",
                 String.format("User '%s' uploaded a new world map", username)
             );
-            return WorldOperationResponse.success("World uploaded successfully. Server is restarting.");
+            return WorldOperationResponse.success(result.message());
         } else {
-            return WorldOperationResponse.error("World upload failed. Check server logs for details.");
+            return WorldOperationResponse.error(result.message());
         }
     }
 
@@ -429,17 +429,15 @@ public class ServerController {
             return Map.of("success", false, "message", "Invalid username or password");
         }
         
-        boolean success = minecraftWrapperService.startServer();
-        
-        if (success) {
+        var result = minecraftWrapperService.startServer();
+
+        if (result.success()) {
             alertNotificationService.sendInfoAlert(
                 "Server Start Initiated",
                 String.format("User '%s' initiated server start", username)
             );
-            return Map.of("success", true, "message", "Server start initiated");
-        } else {
-            return Map.of("success", false, "message", "Failed to start server");
         }
+        return Map.of("success", result.success(), "message", result.message());
     }
     
     @PostMapping("/api/server/stop")
@@ -457,17 +455,15 @@ public class ServerController {
             return Map.of("success", false, "message", "Invalid username or password");
         }
         
-        boolean success = minecraftWrapperService.stopServer();
-        
-        if (success) {
+        var result = minecraftWrapperService.stopServer();
+
+        if (result.success()) {
             alertNotificationService.sendInfoAlert(
                 "Server Stop Initiated",
                 String.format("User '%s' initiated server stop", username)
             );
-            return Map.of("success", true, "message", "Server stop initiated");
-        } else {
-            return Map.of("success", false, "message", "Failed to stop server");
         }
+        return Map.of("success", result.success(), "message", result.message());
     }
     
     @PostMapping("/api/server/restart")
@@ -485,17 +481,15 @@ public class ServerController {
             return Map.of("success", false, "message", "Invalid username or password");
         }
         
-        boolean success = minecraftWrapperService.restartServer();
-        
-        if (success) {
+        var result = minecraftWrapperService.restartServer();
+
+        if (result.success()) {
             alertNotificationService.sendInfoAlert(
                 "Server Restart Initiated",
                 String.format("User '%s' initiated server restart", username)
             );
-            return Map.of("success", true, "message", "Server restart initiated");
-        } else {
-            return Map.of("success", false, "message", "Failed to restart server");
         }
+        return Map.of("success", result.success(), "message", result.message());
     }
     
     @GetMapping("/api/deployment-history")

--- a/web-app/src/main/java/com/openmc/webapp/service/MinecraftWrapperService.java
+++ b/web-app/src/main/java/com/openmc/webapp/service/MinecraftWrapperService.java
@@ -165,7 +165,6 @@ public class MinecraftWrapperService {
      */
     public WrapperResult initiateShutdown() {
         log.info("Initiating server shutdown via wrapper");
-        // Accept both 200 OK and 202 Accepted as success
         return post("/api/server/shutdown", "shut down", "Server shutdown initiated");
     }
 

--- a/web-app/src/main/java/com/openmc/webapp/service/MinecraftWrapperService.java
+++ b/web-app/src/main/java/com/openmc/webapp/service/MinecraftWrapperService.java
@@ -14,10 +14,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -30,6 +31,17 @@ import java.util.Map;
 public class MinecraftWrapperService {
 
     private static final Logger log = LoggerFactory.getLogger(MinecraftWrapperService.class);
+
+    /**
+     * Shown when the wrapper never answered, as opposed to answering with a rejection.
+     */
+    static final String UNREACHABLE_MESSAGE = "Could not reach the Minecraft wrapper";
+
+    /**
+     * Longest wrapper response body echoed onto the dashboard; anything longer is replaced
+     * with a generic message rather than dumping a wall of text into the admin UI.
+     */
+    private static final int MAX_SURFACED_MESSAGE_LENGTH = 200;
 
     @Value("${minecraft.wrapper.url:http://minecraft-wrapper:8092}")
     private String wrapperUrl;
@@ -117,74 +129,44 @@ public class MinecraftWrapperService {
     /**
      * Start the Minecraft server via the wrapper.
      * The start endpoint returns immediately (202 Accepted) and performs start asynchronously.
-     * @return true if start was initiated successfully
+     * It answers 409 Conflict when the server is already running.
+     * @return the outcome, carrying the wrapper's own reason when it rejected the request
      */
-    public boolean startServer() {
-        try {
-            String url = wrapperUrl + "/api/server/start";
-            log.info("Starting server via wrapper");
-            
-            ResponseEntity<String> response = restTemplate.postForEntity(url, null, String.class);
-            return response.getStatusCode().is2xxSuccessful();
-        } catch (Exception e) {
-            log.error("Failed to start server via wrapper: {}", e.getMessage());
-            return false;
-        }
+    public WrapperResult startServer() {
+        log.info("Starting server via wrapper");
+        return post("/api/server/start", "start", "Server start initiated");
     }
 
     /**
      * Stop the Minecraft server via the wrapper.
      * The stop endpoint returns immediately (202 Accepted) and performs stop asynchronously.
-     * @return true if stop was initiated successfully
+     * It answers 409 Conflict when the server is not running.
+     * @return the outcome, carrying the wrapper's own reason when it rejected the request
      */
-    public boolean stopServer() {
-        try {
-            String url = wrapperUrl + "/api/server/stop";
-            log.info("Stopping server via wrapper");
-            
-            ResponseEntity<String> response = restTemplate.postForEntity(url, null, String.class);
-            return response.getStatusCode().is2xxSuccessful();
-        } catch (Exception e) {
-            log.error("Failed to stop server via wrapper: {}", e.getMessage());
-            return false;
-        }
+    public WrapperResult stopServer() {
+        log.info("Stopping server via wrapper");
+        return post("/api/server/stop", "stop", "Server stop initiated");
     }
 
     /**
      * Restart the Minecraft server via the wrapper.
      * The restart endpoint returns immediately (202 Accepted) and performs restart asynchronously.
-     * @return true if restart was initiated successfully
+     * @return the outcome, carrying the wrapper's own reason when it rejected the request
      */
-    public boolean restartServer() {
-        try {
-            String url = wrapperUrl + "/api/server/restart";
-            log.info("Restarting server via wrapper");
-            
-            ResponseEntity<String> response = restTemplate.postForEntity(url, null, String.class);
-            return response.getStatusCode().is2xxSuccessful();
-        } catch (Exception e) {
-            log.error("Failed to restart server via wrapper: {}", e.getMessage());
-            return false;
-        }
+    public WrapperResult restartServer() {
+        log.info("Restarting server via wrapper");
+        return post("/api/server/restart", "restart", "Server restart initiated");
     }
 
     /**
      * Initiate graceful server shutdown via the wrapper.
      * The shutdown endpoint returns immediately (202 Accepted) and performs shutdown asynchronously.
-     * @return true if shutdown was initiated successfully
+     * @return the outcome, carrying the wrapper's own reason when it rejected the request
      */
-    public boolean initiateShutdown() {
-        try {
-            String url = wrapperUrl + "/api/server/shutdown";
-            log.info("Initiating server shutdown via wrapper");
-            
-            ResponseEntity<String> response = restTemplate.postForEntity(url, null, String.class);
-            // Accept both 200 OK and 202 Accepted as success
-            return response.getStatusCode().is2xxSuccessful();
-        } catch (Exception e) {
-            log.error("Failed to initiate shutdown via wrapper: {}", e.getMessage());
-            return false;
-        }
+    public WrapperResult initiateShutdown() {
+        log.info("Initiating server shutdown via wrapper");
+        // Accept both 200 OK and 202 Accepted as success
+        return post("/api/server/shutdown", "shut down", "Server shutdown initiated");
     }
 
     /**
@@ -193,11 +175,12 @@ public class MinecraftWrapperService {
      *
      * @param file            the ZIP archive containing the world
      * @param deployAuthToken the Bearer token for the wrapper's deploy endpoint
-     * @return true if the upload was accepted successfully
+     * @return the outcome, carrying the wrapper's own reason when it rejected the upload
+     *         (e.g. "Invalid request: ..." for a malformed archive)
      */
-    public boolean uploadWorld(MultipartFile file, String deployAuthToken) {
+    public WrapperResult uploadWorld(MultipartFile file, String deployAuthToken) {
+        String url = wrapperUrl + "/api/world/upload";
         try {
-            String url = wrapperUrl + "/api/world/upload";
             log.info("Uploading world to wrapper");
 
             String filename = file.getOriginalFilename() != null ? file.getOriginalFilename() : "world.zip";
@@ -223,10 +206,22 @@ public class MinecraftWrapperService {
 
             HttpEntity<MultiValueMap<String, Object>> request = new HttpEntity<>(body, headers);
             ResponseEntity<String> response = uploadRestTemplate.postForEntity(url, request, String.class);
-            return response.getStatusCode().is2xxSuccessful();
+            if (response.getStatusCode().is2xxSuccessful()) {
+                return WrapperResult.success("World uploaded successfully. Server is restarting.");
+            }
+            return WrapperResult.failure(describeRejection(
+                    response.getStatusCode().value(), response.getBody(), "upload the world"));
+        } catch (HttpStatusCodeException e) {
+            log.warn("Wrapper rejected world upload: {} - {}", e.getStatusCode(), e.getResponseBodyAsString());
+            return WrapperResult.failure(describeRejection(
+                    e.getStatusCode().value(), e.getResponseBodyAsString(), "upload the world"));
+        } catch (RestClientException e) {
+            log.error("Failed to upload world to wrapper at {}: {}", url, e.getMessage());
+            return WrapperResult.failure(UNREACHABLE_MESSAGE);
         } catch (Exception e) {
-            log.error("Failed to upload world to wrapper: {}", e.getMessage());
-            return false;
+            // e.g. the multipart file could not be read back off disk
+            log.error("Failed to upload world to wrapper at {}: {}", url, e.getMessage(), e);
+            return WrapperResult.failure("World upload failed. Check server logs for details.");
         }
     }
 
@@ -236,6 +231,74 @@ public class MinecraftWrapperService {
      */
     public boolean isAvailable() {
         return getServerStatus() != null;
+    }
+
+    /**
+     * POST to a wrapper endpoint that takes no body, preserving the wrapper's own
+     * explanation when it answers with an error status (e.g. 409 "Server is already running").
+     *
+     * @param path           wrapper path to POST to
+     * @param action         verb used in log messages and in the generic fallback message
+     * @param successMessage message shown to the admin when the wrapper accepted the request
+     */
+    private WrapperResult post(String path, String action, String successMessage) {
+        String url = wrapperUrl + path;
+        try {
+            ResponseEntity<String> response = restTemplate.postForEntity(url, null, String.class);
+            if (response.getStatusCode().is2xxSuccessful()) {
+                return WrapperResult.success(successMessage);
+            }
+            return WrapperResult.failure(describeRejection(
+                    response.getStatusCode().value(), response.getBody(), action + " the server"));
+        } catch (HttpStatusCodeException e) {
+            log.warn("Wrapper rejected {} request: {} - {}", action, e.getStatusCode(), e.getResponseBodyAsString());
+            return WrapperResult.failure(describeRejection(
+                    e.getStatusCode().value(), e.getResponseBodyAsString(), action + " the server"));
+        } catch (RestClientException e) {
+            log.error("Failed to {} server via wrapper at {}: {}", action, url, e.getMessage());
+            return WrapperResult.failure(UNREACHABLE_MESSAGE);
+        } catch (Exception e) {
+            log.error("Unexpected failure calling wrapper at {}: {}", url, e.getMessage(), e);
+            return WrapperResult.failure(String.format("Failed to %s the server", action));
+        }
+    }
+
+    /**
+     * Turn a wrapper error response into a message worth showing on the dashboard.
+     *
+     * <p>Only 4xx bodies are surfaced verbatim: those are the wrapper's deliberate,
+     * human-readable rejections (409 "Server is already running", 400 "Invalid request: ...").
+     * A 5xx body may be a framework-generated JSON or HTML error page, which would be noise
+     * on the dashboard, so those fall back to a generic message.
+     */
+    private static String describeRejection(int statusCode, String responseBody, String actionPhrase) {
+        boolean clientError = statusCode >= 400 && statusCode < 500;
+        if (clientError && responseBody != null && !responseBody.isBlank()) {
+            String trimmed = responseBody.trim();
+            boolean looksLikeMarkup = trimmed.startsWith("{") || trimmed.startsWith("<") || trimmed.startsWith("[");
+            if (!looksLikeMarkup && trimmed.length() <= MAX_SURFACED_MESSAGE_LENGTH) {
+                return trimmed;
+            }
+        }
+        return String.format("Failed to %s (HTTP %d)", actionPhrase, statusCode);
+    }
+
+    /**
+     * Outcome of a call to the wrapper.
+     *
+     * @param success whether the wrapper accepted the request
+     * @param message text suitable for display on the admin dashboard — the wrapper's own
+     *                explanation when it answered, or a connectivity message when it did not
+     */
+    public record WrapperResult(boolean success, String message) {
+
+        public static WrapperResult success(String message) {
+            return new WrapperResult(true, message);
+        }
+
+        public static WrapperResult failure(String message) {
+            return new WrapperResult(false, message);
+        }
     }
 
     /**

--- a/web-app/src/test/java/com/openmc/webapp/controller/ServerControllerTest.java
+++ b/web-app/src/test/java/com/openmc/webapp/controller/ServerControllerTest.java
@@ -3,6 +3,7 @@ package com.openmc.webapp.controller;
 import com.openmc.webapp.config.ServerConfig;
 import com.openmc.webapp.service.ActivityTrackerService;
 import com.openmc.webapp.service.AlertNotificationService;
+import com.openmc.webapp.service.MinecraftWrapperService.WrapperResult;
 import com.openmc.webapp.service.PluginService;
 import com.openmc.webapp.service.RconService;
 import com.openmc.webapp.service.WorldService;
@@ -14,6 +15,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Arrays;
@@ -26,11 +28,14 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.never;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.hamcrest.Matchers.containsString;
 
 @WebMvcTest(ServerController.class)
+// The world upload endpoint short-circuits when deploy.auth.token is unset, so give it a value.
+@TestPropertySource(properties = "deploy.auth.token=test-deploy-token")
 @DisplayName("ServerController Tests")
 class ServerControllerTest {
 
@@ -375,8 +380,92 @@ class ServerControllerTest {
     @DisplayName("Should return 404 via API when player not found")
     void shouldReturn404ViaApiWhenPlayerNotFound() throws Exception {
         when(activityTrackerService.getPlayerProfile("UnknownPlayer")).thenReturn(null);
-        
+
         mockMvc.perform(get("/api/player/UnknownPlayer"))
                 .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("Should report the wrapper's success message when starting the server")
+    void shouldReportSuccessMessageOnServerStart() throws Exception {
+        when(minecraftWrapperService.startServer())
+                .thenReturn(WrapperResult.success("Server start initiated"));
+
+        mockMvc.perform(post("/api/server/start")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"username\":\"admin\",\"password\":\"admin\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("Server start initiated"));
+
+        verify(alertNotificationService, times(1)).sendInfoAlert(anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("Should surface the wrapper's rejection reason when starting the server")
+    void shouldSurfaceWrapperReasonOnServerStart() throws Exception {
+        when(minecraftWrapperService.startServer())
+                .thenReturn(WrapperResult.failure("Server is already running"));
+
+        mockMvc.perform(post("/api/server/start")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"username\":\"admin\",\"password\":\"admin\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("Server is already running"));
+
+        // A rejected start is not an event worth alerting on
+        verify(alertNotificationService, never()).sendInfoAlert(anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("Should surface the wrapper's rejection reason when stopping the server")
+    void shouldSurfaceWrapperReasonOnServerStop() throws Exception {
+        when(minecraftWrapperService.stopServer())
+                .thenReturn(WrapperResult.failure("Server is not running"));
+
+        mockMvc.perform(post("/api/server/stop")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"username\":\"admin\",\"password\":\"admin\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("Server is not running"));
+    }
+
+    @Test
+    @DisplayName("Should surface the wrapper's rejection reason when restarting the server")
+    void shouldSurfaceWrapperReasonOnServerRestart() throws Exception {
+        when(minecraftWrapperService.restartServer())
+                .thenReturn(WrapperResult.failure("Could not reach the Minecraft wrapper"));
+
+        mockMvc.perform(post("/api/server/restart")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"username\":\"admin\",\"password\":\"admin\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("Could not reach the Minecraft wrapper"));
+    }
+
+    @Test
+    @DisplayName("Should surface the wrapper's validation reason when a world upload is rejected")
+    void shouldSurfaceWrapperReasonOnWorldUpload() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "world.zip",
+            "application/zip",
+            "test content".getBytes()
+        );
+
+        when(minecraftWrapperService.uploadWorld(any(), anyString()))
+                .thenReturn(WrapperResult.failure("Invalid request: archive does not contain a level.dat"));
+
+        mockMvc.perform(multipart("/api/world/upload")
+                        .file(file)
+                        .param("username", "admin")
+                        .param("password", "admin"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error")
+                        .value("Invalid request: archive does not contain a level.dat"));
     }
 }

--- a/web-app/src/test/java/com/openmc/webapp/service/MinecraftWrapperServiceTest.java
+++ b/web-app/src/test/java/com/openmc/webapp/service/MinecraftWrapperServiceTest.java
@@ -1,0 +1,260 @@
+package com.openmc.webapp.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MinecraftWrapperService Tests")
+class MinecraftWrapperServiceTest {
+
+    private static final String WRAPPER_URL = "http://test-wrapper:8092";
+    private static final String START_URL = WRAPPER_URL + "/api/server/start";
+    private static final String STOP_URL = WRAPPER_URL + "/api/server/stop";
+    private static final String RESTART_URL = WRAPPER_URL + "/api/server/restart";
+    private static final String UPLOAD_URL = WRAPPER_URL + "/api/world/upload";
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @Mock
+    private RestTemplateBuilder restTemplateBuilder;
+
+    @Captor
+    private ArgumentCaptor<HttpEntity<?>> requestCaptor;
+
+    private MinecraftWrapperService service;
+
+    @BeforeEach
+    void setUp() {
+        when(restTemplateBuilder.setConnectTimeout(any())).thenReturn(restTemplateBuilder);
+        when(restTemplateBuilder.setReadTimeout(any())).thenReturn(restTemplateBuilder);
+        when(restTemplateBuilder.build()).thenReturn(restTemplate);
+
+        service = new MinecraftWrapperService(restTemplateBuilder);
+        ReflectionTestUtils.setField(service, "wrapperUrl", WRAPPER_URL);
+    }
+
+    private static HttpClientErrorException clientError(HttpStatus status, String body) {
+        return HttpClientErrorException.create(
+                status,
+                status.getReasonPhrase(),
+                HttpHeaders.EMPTY,
+                body == null ? null : body.getBytes(StandardCharsets.UTF_8),
+                StandardCharsets.UTF_8);
+    }
+
+    @Test
+    @DisplayName("Should report success when wrapper accepts a start request")
+    void shouldReportSuccessOnStartAccepted() {
+        when(restTemplate.postForEntity(eq(START_URL), isNull(), eq(String.class)))
+                .thenReturn(ResponseEntity.accepted().body("Server start initiated"));
+
+        MinecraftWrapperService.WrapperResult result = service.startServer();
+
+        assertTrue(result.success());
+        assertEquals("Server start initiated", result.message());
+    }
+
+    @Test
+    @DisplayName("Should surface the wrapper's 409 reason when the server is already running")
+    void shouldSurfaceConflictReasonOnStart() {
+        when(restTemplate.postForEntity(eq(START_URL), isNull(), eq(String.class)))
+                .thenThrow(clientError(HttpStatus.CONFLICT, "Server is already running"));
+
+        MinecraftWrapperService.WrapperResult result = service.startServer();
+
+        assertFalse(result.success());
+        assertEquals("Server is already running", result.message());
+    }
+
+    @Test
+    @DisplayName("Should surface the wrapper's 409 reason when the server is not running")
+    void shouldSurfaceConflictReasonOnStop() {
+        when(restTemplate.postForEntity(eq(STOP_URL), isNull(), eq(String.class)))
+                .thenThrow(clientError(HttpStatus.CONFLICT, "Server is not running"));
+
+        MinecraftWrapperService.WrapperResult result = service.stopServer();
+
+        assertFalse(result.success());
+        assertEquals("Server is not running", result.message());
+    }
+
+    @Test
+    @DisplayName("Should report success when wrapper accepts a restart request")
+    void shouldReportSuccessOnRestartAccepted() {
+        when(restTemplate.postForEntity(eq(RESTART_URL), isNull(), eq(String.class)))
+                .thenReturn(ResponseEntity.accepted().body("Server restart initiated"));
+
+        MinecraftWrapperService.WrapperResult result = service.restartServer();
+
+        assertTrue(result.success());
+        assertEquals("Server restart initiated", result.message());
+    }
+
+    @Test
+    @DisplayName("Should distinguish an unreachable wrapper from a rejected request")
+    void shouldReportUnreachableWrapper() {
+        when(restTemplate.postForEntity(eq(START_URL), isNull(), eq(String.class)))
+                .thenThrow(new ResourceAccessException("Connection refused"));
+
+        MinecraftWrapperService.WrapperResult result = service.startServer();
+
+        assertFalse(result.success());
+        assertEquals(MinecraftWrapperService.UNREACHABLE_MESSAGE, result.message());
+    }
+
+    @Test
+    @DisplayName("Should fall back to the status code when a 4xx carries no body")
+    void shouldFallBackWhenRejectionHasNoBody() {
+        when(restTemplate.postForEntity(eq(STOP_URL), isNull(), eq(String.class)))
+                .thenThrow(clientError(HttpStatus.CONFLICT, ""));
+
+        MinecraftWrapperService.WrapperResult result = service.stopServer();
+
+        assertFalse(result.success());
+        assertEquals("Failed to stop the server (HTTP 409)", result.message());
+    }
+
+    @Test
+    @DisplayName("Should not echo a framework-generated 5xx error body onto the dashboard")
+    void shouldNotEchoServerErrorBody() {
+        when(restTemplate.postForEntity(eq(RESTART_URL), isNull(), eq(String.class)))
+                .thenThrow(HttpServerErrorException.create(
+                        HttpStatus.INTERNAL_SERVER_ERROR,
+                        "Internal Server Error",
+                        HttpHeaders.EMPTY,
+                        "{\"timestamp\":\"2026-01-01\",\"status\":500,\"error\":\"Internal Server Error\"}"
+                                .getBytes(StandardCharsets.UTF_8),
+                        StandardCharsets.UTF_8));
+
+        MinecraftWrapperService.WrapperResult result = service.restartServer();
+
+        assertFalse(result.success());
+        assertEquals("Failed to restart the server (HTTP 500)", result.message());
+    }
+
+    @Test
+    @DisplayName("Should not echo a JSON-shaped 4xx body onto the dashboard")
+    void shouldNotEchoJsonClientErrorBody() {
+        when(restTemplate.postForEntity(eq(START_URL), isNull(), eq(String.class)))
+                .thenThrow(clientError(HttpStatus.BAD_REQUEST, "{\"error\":\"bad request\"}"));
+
+        MinecraftWrapperService.WrapperResult result = service.startServer();
+
+        assertFalse(result.success());
+        assertEquals("Failed to start the server (HTTP 400)", result.message());
+    }
+
+    @Test
+    @DisplayName("Should not echo an over-long 4xx body onto the dashboard")
+    void shouldNotEchoOverlongClientErrorBody() {
+        when(restTemplate.postForEntity(eq(START_URL), isNull(), eq(String.class)))
+                .thenThrow(clientError(HttpStatus.BAD_REQUEST, "x".repeat(201)));
+
+        MinecraftWrapperService.WrapperResult result = service.startServer();
+
+        assertFalse(result.success());
+        assertEquals("Failed to start the server (HTTP 400)", result.message());
+    }
+
+    @Test
+    @DisplayName("Should treat a non-2xx response returned without an exception as a rejection")
+    void shouldTreatNon2xxResponseAsRejection() {
+        when(restTemplate.postForEntity(eq(START_URL), isNull(), eq(String.class)))
+                .thenReturn(ResponseEntity.status(HttpStatus.CONFLICT).body("Server is already running"));
+
+        MinecraftWrapperService.WrapperResult result = service.startServer();
+
+        assertFalse(result.success());
+        assertEquals("Server is already running", result.message());
+    }
+
+    @Test
+    @DisplayName("Should report success when the wrapper accepts a world upload")
+    void shouldReportSuccessOnWorldUpload() {
+        when(restTemplate.postForEntity(eq(UPLOAD_URL), any(HttpEntity.class), eq(String.class)))
+                .thenReturn(ResponseEntity.ok("World uploaded successfully"));
+
+        MinecraftWrapperService.WrapperResult result = service.uploadWorld(worldZip(), "secret-token");
+
+        assertTrue(result.success());
+        assertEquals("World uploaded successfully. Server is restarting.", result.message());
+    }
+
+    @Test
+    @DisplayName("Should surface the wrapper's validation reason for a rejected world upload")
+    void shouldSurfaceWorldUploadValidationReason() {
+        when(restTemplate.postForEntity(eq(UPLOAD_URL), any(HttpEntity.class), eq(String.class)))
+                .thenThrow(clientError(HttpStatus.BAD_REQUEST,
+                        "Invalid request: archive does not contain a level.dat"));
+
+        MinecraftWrapperService.WrapperResult result = service.uploadWorld(worldZip(), "secret-token");
+
+        assertFalse(result.success());
+        assertEquals("Invalid request: archive does not contain a level.dat", result.message());
+    }
+
+    @Test
+    @DisplayName("Should surface an unauthorized world upload distinctly from an unreachable wrapper")
+    void shouldSurfaceWorldUploadUnauthorized() {
+        when(restTemplate.postForEntity(eq(UPLOAD_URL), any(HttpEntity.class), eq(String.class)))
+                .thenThrow(clientError(HttpStatus.UNAUTHORIZED, "Unauthorized"));
+
+        MinecraftWrapperService.WrapperResult result = service.uploadWorld(worldZip(), "wrong-token");
+
+        assertFalse(result.success());
+        assertEquals("Unauthorized", result.message());
+    }
+
+    @Test
+    @DisplayName("Should report an unreachable wrapper for a world upload")
+    void shouldReportUnreachableWrapperOnWorldUpload() {
+        when(restTemplate.postForEntity(eq(UPLOAD_URL), any(HttpEntity.class), eq(String.class)))
+                .thenThrow(new ResourceAccessException("Connection refused"));
+
+        MinecraftWrapperService.WrapperResult result = service.uploadWorld(worldZip(), "secret-token");
+
+        assertFalse(result.success());
+        assertEquals(MinecraftWrapperService.UNREACHABLE_MESSAGE, result.message());
+    }
+
+    @Test
+    @DisplayName("Should send the deploy token as a Bearer header on world upload")
+    void shouldSendBearerTokenOnWorldUpload() {
+        when(restTemplate.postForEntity(eq(UPLOAD_URL), any(HttpEntity.class), eq(String.class)))
+                .thenReturn(ResponseEntity.ok("World uploaded successfully"));
+
+        service.uploadWorld(worldZip(), "secret-token");
+
+        verify(restTemplate).postForEntity(eq(UPLOAD_URL), requestCaptor.capture(), eq(String.class));
+        assertEquals("Bearer secret-token",
+                requestCaptor.getValue().getHeaders().getFirst(HttpHeaders.AUTHORIZATION));
+    }
+
+    private static MockMultipartFile worldZip() {
+        return new MockMultipartFile("file", "world.zip", "application/zip", "not-really-a-zip".getBytes(StandardCharsets.UTF_8));
+    }
+}


### PR DESCRIPTION
## Summary

- `web-app`'s `MinecraftWrapperService` returned a bare `boolean` for every wrapper call and caught `Exception` around the `RestTemplate` invocation. Because `RestTemplate` throws on 4xx, a *deliberate precondition rejection* and *the wrapper being unreachable* both collapsed to `false`, so the admin dashboard could only ever say `✗ Failed to start server`.
- The wrapper is specific about these cases — `409 "Server is already running"`, `409 "Server is not running"` (added in #194), `401 "Unauthorized"` and `400 "Invalid request: <reason>"` on world upload — and all of it was being discarded.
- `startServer` / `stopServer` / `restartServer` / `initiateShutdown` / `uploadWorld` now return a `WrapperResult` record (`success` + `message`), catching `HttpStatusCodeException` separately from `RestClientException`. `ServerController`'s four call sites pass the message straight through.
- Only **4xx** bodies are echoed verbatim. 5xx bodies, JSON/HTML-shaped bodies and bodies over 200 characters fall back to `Failed to <action> (HTTP <code>)`, so a framework-generated error page can never be dumped into the admin UI. A wrapper that never answered yields a distinct `Could not reach the Minecraft wrapper`.
- `admin.html:910` already renders `data.message` verbatim, so no frontend change was needed.
- Adds `BearerTokenAuthenticatorTest` — that class is the fail-closed authorization gate for both write-capable deploy endpoints (`PluginDeployController`, `WorldUploadController`) and had no tests.

Examples of what an admin now sees instead of `✗ Failed to start server`:

- `✗ Server is already running`
- `✗ Invalid request: archive does not contain a level.dat`
- `✗ Could not reach the Minecraft wrapper`

## Test plan

- [x] `web-app`: new `MinecraftWrapperServiceTest` (15 tests) covers accepted requests, 409/400/401 reason pass-through, unreachable wrapper, empty 4xx body, 5xx body suppression, JSON-shaped body suppression, over-long body suppression, non-2xx returned without an exception, and the Bearer header on upload
- [x] `web-app`: `ServerControllerTest` extended (26 tests) asserting the reason reaches the JSON `message` / `error` field for start, stop, restart and world upload, and that a rejected start sends no info alert
- [x] `minecraft-wrapper`: new `BearerTokenAuthenticatorTest` (9 tests) pinning the fail-closed behaviour for unconfigured/blank tokens, missing header, wrong scheme, partial/case-mismatched tokens
- [x] `cd web-app && ./gradlew build test` — BUILD SUCCESSFUL
- [x] `cd minecraft-wrapper && ./gradlew build test` — BUILD SUCCESSFUL

### Docker Compose / Kubernetes parity

This change is confined to Java source in `web-app` and a test in `minecraft-wrapper`. It introduces **no new environment variables, no new config knobs, and no new inter-service traffic paths**, so `compose.yml`, `sample.env`, `helm/omcsi/templates/` (including `networkpolicies.yaml`) and `values.yaml` all remain correct as-is — both deployment targets are unaffected.

- [ ] `helm lint` / `helm unittest helm/omcsi` / `docker compose config` — not runnable in this environment; delegated to CI, which runs all three plus the kind-based Helm deploy smoke test

Closes #207
Closes #208

<!-- gardener-tend-dispatch -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._