### PR TITLE
feat(nginx): make the upload size limit configurable on both deployment targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -812,6 +812,8 @@ Plugin JARs and world archives are uploaded through the nginx reverse proxy, so 
 
 To allow larger uploads, raise `NGINX_MAX_BODY_SIZE` and keep the two web app limits at or above it. Note the suffixes differ: nginx uses `100M` / `2G`, Spring uses `100MB` / `2048MB`.
 
+World uploads are forwarded to the minecraft-wrapper, whose own multipart limit is fixed at `2048MB`, so that is the ceiling for a world archive regardless of the settings above. Plugin uploads are written directly by the web app and are not subject to it.
+
 On Kubernetes the equivalent values are `nginx.maxBodySize`, `webapp.env.MAX_FILE_UPLOAD_SIZE`, and `webapp.env.MAX_REQUEST_UPLOAD_SIZE` in `helm/omcsi/values.yaml`.
 
 ### Backup Manager Configuration

--- a/README.md
+++ b/README.md
@@ -802,6 +802,18 @@ docker compose --env-file .env.dev2 up -d --build
 
 **Note**: The RCON password must match between the server and web application for admin commands to work. Change the admin username and password from defaults in production for security. All connections to the web dashboard are encrypted using HTTPS to protect your credentials.
 
+#### Upload Size Limits
+
+Plugin JARs and world archives are uploaded through the nginx reverse proxy, so the proxy limit is the effective cap — a larger request is rejected with a bare `413 Request Entity Too Large` before the dashboard's own error handling runs.
+
+- `NGINX_MAX_BODY_SIZE`: Maximum request body accepted by nginx (default: `100M`)
+- `MAX_FILE_UPLOAD_SIZE`: Web app per-file multipart limit (default: `2048MB`)
+- `MAX_REQUEST_UPLOAD_SIZE`: Web app total request multipart limit (default: `2048MB`)
+
+To allow larger uploads, raise `NGINX_MAX_BODY_SIZE` and keep the two web app limits at or above it. Note the suffixes differ: nginx uses `100M` / `2G`, Spring uses `100MB` / `2048MB`.
+
+On Kubernetes the equivalent values are `nginx.maxBodySize`, `webapp.env.MAX_FILE_UPLOAD_SIZE`, and `webapp.env.MAX_REQUEST_UPLOAD_SIZE` in `helm/omcsi/values.yaml`.
+
 ### Backup Manager Configuration
 
 - `BACKUP_CONTAINER_NAME`: Backup manager container name (default: `open-mc-backup-manager`)

--- a/compose.yml
+++ b/compose.yml
@@ -111,6 +111,9 @@ services:
       - ACCORDION_CHAT_URL=${ACCORDION_CHAT_URL:-}
       - DEPLOYMENT_AUTH_TOKEN=${DEPLOYMENT_AUTH_TOKEN:-}
       - WORLD_DIRECTORY=${WORLD_DIRECTORY:-/mcserver/world}
+      # Spring multipart limits. nginx (NGINX_MAX_BODY_SIZE) is the effective cap.
+      - MAX_FILE_UPLOAD_SIZE=${MAX_FILE_UPLOAD_SIZE:-2048MB}
+      - MAX_REQUEST_UPLOAD_SIZE=${MAX_REQUEST_UPLOAD_SIZE:-2048MB}
 
   nginx:
     build:
@@ -121,6 +124,10 @@ services:
     ports:
       - "${WEB_HTTP_PORT:-8080}:80"
       - "${WEB_HTTPS_PORT:-8443}:443"
+    environment:
+      # Maximum request body size accepted by the proxy. This is the effective
+      # upload cap for the dashboard — raise it alongside MAX_FILE_UPLOAD_SIZE.
+      - NGINX_MAX_BODY_SIZE=${NGINX_MAX_BODY_SIZE:-100M}
     depends_on:
       - webapp
     healthcheck:

--- a/helm/omcsi/templates/nginx-configmap.yaml
+++ b/helm/omcsi/templates/nginx-configmap.yaml
@@ -13,7 +13,10 @@ data:
     }
 
     http {
-        client_max_body_size 100M;
+        # File upload size limit.  This is the effective cap for dashboard
+        # uploads whenever it is lower than the web app's own multipart limit
+        # (webapp.env.MAX_FILE_UPLOAD_SIZE).
+        client_max_body_size {{ .Values.nginx.maxBodySize }};
 
         # Security headers
         add_header X-Frame-Options "SAMEORIGIN" always;

--- a/helm/omcsi/templates/webapp.yaml
+++ b/helm/omcsi/templates/webapp.yaml
@@ -127,6 +127,10 @@ spec:
               value: {{ .Values.webapp.env.MINECRAFT_WRAPPER_ENABLED | quote }}
             - name: WORLD_DIRECTORY
               value: {{ .Values.webapp.env.WORLD_DIRECTORY | quote }}
+            - name: MAX_FILE_UPLOAD_SIZE
+              value: {{ .Values.webapp.env.MAX_FILE_UPLOAD_SIZE | quote }}
+            - name: MAX_REQUEST_UPLOAD_SIZE
+              value: {{ .Values.webapp.env.MAX_REQUEST_UPLOAD_SIZE | quote }}
             - name: DEPLOYMENT_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/helm/omcsi/tests/nginx_test.yaml
+++ b/helm/omcsi/tests/nginx_test.yaml
@@ -56,6 +56,31 @@ tests:
           path: spec.ports[1].nodePort
           value: 443
 
+  - it: config map caps request bodies at the default upload size limit
+    documentSelector:
+      path: kind
+      value: ConfigMap
+      skipEmptyTemplates: true
+    asserts:
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: "client_max_body_size 100M;"
+
+  - it: upload size limit is configurable via nginx.maxBodySize
+    set:
+      nginx.maxBodySize: 2G
+    documentSelector:
+      path: kind
+      value: ConfigMap
+      skipEmptyTemplates: true
+    asserts:
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: "client_max_body_size 2G;"
+      - notMatchRegex:
+          path: data["nginx.conf"]
+          pattern: "client_max_body_size 100M;"
+
   - it: nodePorts are ignored for non-NodePort service types
     set:
       nginx.service.type: LoadBalancer

--- a/helm/omcsi/tests/webapp_test.yaml
+++ b/helm/omcsi/tests/webapp_test.yaml
@@ -103,3 +103,36 @@ tests:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.port
           value: http
         documentIndex: 0
+
+  - it: renders the Spring multipart upload limits
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MAX_FILE_UPLOAD_SIZE
+            value: "2048MB"
+        documentIndex: 0
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MAX_REQUEST_UPLOAD_SIZE
+            value: "2048MB"
+        documentIndex: 0
+
+  - it: upload limits are configurable
+    set:
+      webapp.env.MAX_FILE_UPLOAD_SIZE: 512MB
+      webapp.env.MAX_REQUEST_UPLOAD_SIZE: 512MB
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MAX_FILE_UPLOAD_SIZE
+            value: "512MB"
+        documentIndex: 0
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MAX_REQUEST_UPLOAD_SIZE
+            value: "512MB"
+        documentIndex: 0

--- a/helm/omcsi/values.yaml
+++ b/helm/omcsi/values.yaml
@@ -119,6 +119,9 @@ webapp:
     DASHBOARD_DARK_MODE: "true"
     ALERT_MANAGER_ENABLED: "true"
     ACCORDION_CHAT_URL: ""
+    # Spring multipart limits.  nginx.maxBodySize is the effective upload cap.
+    MAX_FILE_UPLOAD_SIZE: "2048MB"
+    MAX_REQUEST_UPLOAD_SIZE: "2048MB"
     MINECRAFT_WRAPPER_ENABLED: "true"
     WORLD_DIRECTORY: "/mcserver/world"
   # webapp mounts the mcserver and webapp-data PVCs directly. Scaling beyond
@@ -143,6 +146,13 @@ nginx:
     tag: latest
     pullPolicy: Always
   replicaCount: 1
+  # Maximum request body size accepted by the proxy (nginx client_max_body_size).
+  # nginx sits in front of the web app, so this is the effective upload cap for
+  # plugin JARs and world archives: a larger request is rejected with a bare 413
+  # before the dashboard sees it.  Raise it together with
+  # webapp.env.MAX_FILE_UPLOAD_SIZE / MAX_REQUEST_UPLOAD_SIZE, which use Spring's
+  # "2048MB" suffix rather than nginx's "2G".
+  maxBodySize: 100M
   resources:
     requests:
       cpu: "50m"

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -9,8 +9,10 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     setcap cap_net_bind_service=+ep /usr/sbin/nginx
 
-# Copy nginx configuration
-COPY nginx.conf /etc/nginx/nginx.conf
+# Copy nginx configuration.  It is owned by UID 1000 so that entrypoint.sh can
+# substitute NGINX_MAX_BODY_SIZE into it at startup; on Kubernetes this file is
+# replaced by a read-only ConfigMap mount and the substitution is skipped.
+COPY --chown=1000:1000 nginx.conf /etc/nginx/nginx.conf
 
 # Create SSL directory owned by UID 1000 so entrypoint can write certs without root
 RUN mkdir -p /etc/nginx/ssl && chown 1000:1000 /etc/nginx/ssl

--- a/nginx/entrypoint.sh
+++ b/nginx/entrypoint.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 
 # Entrypoint script for nginx container
-# Generates self-signed SSL certificates if they don't exist
+# Generates self-signed SSL certificates if they don't exist and applies the
+# configurable upload size limit
 
 set -e
 
 SSL_CERT="/etc/nginx/ssl/cert.pem"
 SSL_KEY="/etc/nginx/ssl/key.pem"
+NGINX_CONF="/etc/nginx/nginx.conf"
 
 # Check if SSL certificates exist
 if [ ! -f "$SSL_CERT" ] || [ ! -f "$SSL_KEY" ]; then
@@ -22,6 +24,27 @@ if [ ! -f "$SSL_CERT" ] || [ ! -f "$SSL_KEY" ]; then
     echo "For production, replace with certificates from a trusted CA."
 else
     echo "Using existing SSL certificates."
+fi
+
+# Apply the configurable upload size limit.
+#
+# Under Docker Compose nginx.conf is baked into the image and writable by the
+# container user, so NGINX_MAX_BODY_SIZE is substituted in here. On Kubernetes
+# nginx.conf is a read-only ConfigMap subPath mount that the Helm chart has
+# already rendered from .Values.nginx.maxBodySize, so the substitution is
+# skipped rather than failing on the read-only filesystem.
+if [ -w "$NGINX_CONF" ]; then
+    NGINX_MAX_BODY_SIZE="${NGINX_MAX_BODY_SIZE:-100M}"
+    # Rewritten by truncating the file rather than with `sed -i`: /etc/nginx is
+    # root-owned, so the container user (UID 1000) cannot create sed's temporary
+    # file alongside it, but it can rewrite the file itself.
+    sed "s/client_max_body_size [^;]*;/client_max_body_size ${NGINX_MAX_BODY_SIZE};/" \
+        "$NGINX_CONF" > /tmp/nginx.conf.tmp
+    cat /tmp/nginx.conf.tmp > "$NGINX_CONF"
+    rm -f /tmp/nginx.conf.tmp
+    echo "Maximum request body size set to ${NGINX_MAX_BODY_SIZE}."
+else
+    echo "$NGINX_CONF is not writable; using its configured client_max_body_size."
 fi
 
 # Execute the command passed to the container

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -5,7 +5,10 @@ events {
 }
 
 http {
-    # File upload size limit (must match application limit)
+    # File upload size limit. Substituted from NGINX_MAX_BODY_SIZE by
+    # entrypoint.sh at startup. This is the effective cap for dashboard uploads
+    # whenever it is lower than the web app's own multipart limit
+    # (MAX_FILE_UPLOAD_SIZE), which it is by default.
     client_max_body_size 100M;
 
     # Security headers

--- a/sample.env
+++ b/sample.env
@@ -49,6 +49,8 @@ VOLUME_NAME=mcserver
 WEB_CONTAINER_NAME=open-mc-webapp
 # Web app data volume name - change this to use separate data for parallel servers
 WEBAPP_VOLUME_NAME=webapp-data
+# Alert manager data volume name - change this to use separate data for parallel servers
+ALERT_MANAGER_VOLUME_NAME=alert-manager-data
 # Backups volume name
 BACKUPS_VOLUME_NAME=backups
 # Nginx SSL cert volume name
@@ -61,6 +63,16 @@ NGINX_CONTAINER_NAME=open-mc-nginx
 WEB_HTTP_PORT=8080
 # Web application HTTPS port (default: 8443)
 WEB_HTTPS_PORT=8443
+
+# Upload size limits (plugin JARs and world archives)
+# nginx sits in front of the web app, so NGINX_MAX_BODY_SIZE is the effective cap:
+# a larger request is rejected with a bare 413 before the dashboard ever sees it.
+# To allow bigger uploads, raise all three together. Note the different suffixes —
+# nginx uses 100M / 2G, Spring uses 100MB / 2048MB.
+NGINX_MAX_BODY_SIZE=100M
+MAX_FILE_UPLOAD_SIZE=2048MB
+MAX_REQUEST_UPLOAD_SIZE=2048MB
+
 # RCON password for web app to connect to server
 RCON_PASSWORD=minecraft
 # Admin credentials for web dashboard
@@ -97,6 +109,9 @@ DEPLOYMENT_AUTH_TOKEN=
 
 # Whether the minecraft-wrapper integration is enabled in the web app (default: true)
 MINECRAFT_WRAPPER_ENABLED=true
+# Minecraft wrapper REST API URL used by the web app and agent manager.
+# Docker Compose only — the Helm chart derives this from the in-cluster Service.
+MINECRAFT_WRAPPER_URL=http://minecraft-wrapper:8092
 
 # Alert Manager integration for web app actions (default: true)
 ALERT_MANAGER_ENABLED=true
@@ -130,6 +145,13 @@ ALERT_MANAGER_URL=http://alert-manager:8090/api/alerts
 DISCORD_WEBHOOK_URL=
 # Enable/disable Discord notifications (default: false)
 DISCORD_ENABLED=false
+# RCON connection the alert manager uses to broadcast alerts in-game via "say".
+# MINECRAFT_RCON_HOST/PORT are Docker Compose only — the Helm chart derives them
+# from the in-cluster minecraft-wrapper Service. The password comes from RCON_PASSWORD above.
+MINECRAFT_RCON_HOST=minecraft-wrapper
+MINECRAFT_RCON_PORT=25575
+# Whether the alert manager broadcasts alerts in-game over RCON at all (default: true)
+MINECRAFT_RCON_ENABLED=true
 
 # Agent Manager Configuration
 # Agent manager container name


### PR DESCRIPTION
## Summary

- **Upload cap was hardcoded and wrong.** `nginx` capped every request body at `100M` with the comment "must match application limit", but the application limit is `2048MB` (`web-app` and `minecraft-wrapper` `application.properties`). nginx fronts all dashboard traffic, so a world archive over 100 MB was rejected with a bare `413 Request Entity Too Large` before the dashboard's own error handling ran — and there was no way to raise it short of forking `nginx/nginx.conf` and rebuilding the image.
- **Docker**: `NGINX_MAX_BODY_SIZE` is substituted into the baked `nginx.conf` by `nginx/entrypoint.sh`. `MAX_FILE_UPLOAD_SIZE` / `MAX_REQUEST_UPLOAD_SIZE` — already read by `web-app`'s `application.properties` but set nowhere — are now passed through to the `webapp` service.
- **Kubernetes**: `nginx.maxBodySize` is rendered into the nginx ConfigMap; the two Spring limits are rendered into the webapp Deployment. Defaults live in `values.yaml`.
- The entrypoint substitution is a no-op when `nginx.conf` is not writable, which is exactly the Kubernetes case (read-only ConfigMap `subPath` mount that the chart has already rendered, under `readOnlyRootFilesystem: true`). It rewrites the file by truncation rather than with `sed -i`, because `/etc/nginx` is root-owned and UID 1000 cannot create sed's temporary file alongside it.
- **Defaults are unchanged** (`100M` / `2048MB`), so nothing changes until an operator raises them.
- Documents four env vars substituted from `.env` by `compose.yml` but absent from `sample.env` (`MINECRAFT_WRAPPER_URL`, `MINECRAFT_RCON_HOST`, `MINECRAFT_RCON_PORT`, `MINECRAFT_RCON_ENABLED`), plus `ALERT_MANAGER_VOLUME_NAME` — the only volume-name knob that was undocumented. All five are Docker-side gaps; the chart derives the equivalents from in-cluster Services and PVC templates, so no Helm change was needed for them.

## Test plan

Both deployment targets per `CLAUDE.md`:

- [x] `compose.yml` updated — `NGINX_MAX_BODY_SIZE` on `nginx`, `MAX_FILE_UPLOAD_SIZE` / `MAX_REQUEST_UPLOAD_SIZE` on `webapp`
- [x] `sample.env` updated — all new vars plus the five previously undocumented ones
- [x] Helm chart updated — `nginx.maxBodySize` in `nginx-configmap.yaml`, upload limits in `webapp.yaml`, defaults in `values.yaml`
- [x] NetworkPolicies — no new inter-service traffic path is introduced, so no change required
- [x] `helm unittest` coverage added — `nginx_test.yaml` asserts the default and an overridden `client_max_body_size`; `webapp_test.yaml` asserts both Spring limits render and are configurable
- [x] `entrypoint.sh` substitution exercised locally against a copy of `nginx.conf` in a non-writable directory (rewrites correctly, exit 0) and against a read-only config (skips cleanly, exit 0)
- [x] YAML syntax validated for `compose.yml`, `values.yaml`, and both test suites; `bash -n` clean on `entrypoint.sh`
- [ ] `docker compose config`, `helm lint`, `helm unittest`, and `helm template` — delegated to CI; Docker and Helm are unavailable in this environment

Closes #210
Closes #211
Closes #212

<!-- gardener-tend-dispatch -->



---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._