### PR TITLE
fix: stage world uploads on the world volume and wire WORLD_DIRECTORY to the wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -816,6 +816,8 @@ World uploads are forwarded to the minecraft-wrapper, whose own multipart limit 
 
 On Kubernetes the equivalent values are `nginx.maxBodySize`, `webapp.env.MAX_FILE_UPLOAD_SIZE`, and `webapp.env.MAX_REQUEST_UPLOAD_SIZE` in `helm/omcsi/values.yaml`.
 
+**Disk headroom for world uploads**: a world archive is extracted into a staging directory next to the world directory — on the same volume — before being renamed into place, because a rename cannot cross filesystems. The server volume therefore needs enough free space to hold the old world and the extracted new one at the same time, roughly twice the size of the larger of the two. Plan for this when sizing the volume (`persistence.mcserver.size` on Kubernetes, default `10Gi`); a world upload that runs out of space fails and leaves the existing world in place. The extracted size is capped at 10 GB regardless.
+
 ### Backup Manager Configuration
 
 - `BACKUP_CONTAINER_NAME`: Backup manager container name (default: `open-mc-backup-manager`)

--- a/backup-manager/src/main/java/com/openmc/backupmanager/service/BackupService.java
+++ b/backup-manager/src/main/java/com/openmc/backupmanager/service/BackupService.java
@@ -417,17 +417,19 @@ public class BackupService {
             return 0;
         }
         
-        return Files.walk(directory)
-                .filter(Files::isRegularFile)
-                .mapToLong(path -> {
-                    try {
-                        return Files.size(path);
-                    } catch (IOException e) {
-                        log.warn("Error getting size of file: {}", path, e);
-                        return 0L;
-                    }
-                })
-                .sum();
+        try (Stream<Path> paths = Files.walk(directory)) {
+            return paths
+                    .filter(Files::isRegularFile)
+                    .mapToLong(path -> {
+                        try {
+                            return Files.size(path);
+                        } catch (IOException e) {
+                            log.warn("Error getting size of file: {}", path, e);
+                            return 0L;
+                        }
+                    })
+                    .sum();
+        }
     }
 
     private void deleteDirectory(Path directory) throws IOException {

--- a/compose.yml
+++ b/compose.yml
@@ -59,6 +59,10 @@ services:
       # Plugin deployment CI/CD configuration
       - DEPLOY_AUTH_TOKEN=${DEPLOY_AUTH_TOKEN:-}
       - PLUGINS_DIRECTORY=${PLUGINS_DIRECTORY:-/mcserver/plugins}
+      # World directory. Must match the webapp's WORLD_DIRECTORY below: the webapp
+      # lists/deletes worlds under this path while the wrapper installs uploaded
+      # worlds there, so a mismatch silently hides uploads from the dashboard.
+      - WORLD_DIRECTORY=${WORLD_DIRECTORY:-/mcserver/world}
       # Web app integration
       - WEBAPP_URL=${WEBAPP_URL:-http://webapp:8080}
       - DEPLOYMENT_AUTH_TOKEN=${DEPLOYMENT_AUTH_TOKEN:-}

--- a/helm/omcsi/templates/minecraft-wrapper.yaml
+++ b/helm/omcsi/templates/minecraft-wrapper.yaml
@@ -104,6 +104,8 @@ spec:
                   key: DEPLOY_AUTH_TOKEN
             - name: PLUGINS_DIRECTORY
               value: {{ .Values.minecraftWrapper.env.PLUGINS_DIRECTORY | quote }}
+            - name: WORLD_DIRECTORY
+              value: {{ .Values.minecraftWrapper.env.WORLD_DIRECTORY | quote }}
             - name: WEBAPP_URL
               value: "http://{{ include "omcsi.webappHost" . }}:{{ .Values.webapp.service.port }}"
             - name: DEPLOYMENT_AUTH_TOKEN

--- a/helm/omcsi/tests/minecraft_wrapper_test.yaml
+++ b/helm/omcsi/tests/minecraft_wrapper_test.yaml
@@ -228,3 +228,26 @@ tests:
             name: ALERTS_CONFIG_WARNING
             value: "false"
         documentIndex: 0
+
+  # The wrapper installs uploaded worlds at world.directory; the webapp lists and
+  # deletes worlds under its own WORLD_DIRECTORY. Both must be fed the same value,
+  # or an upload lands somewhere the dashboard never looks.
+  - it: renders WORLD_DIRECTORY so uploads land where the webapp looks
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WORLD_DIRECTORY
+            value: /mcserver/world
+        documentIndex: 0
+
+  - it: honours an overridden WORLD_DIRECTORY
+    set:
+      minecraftWrapper.env.WORLD_DIRECTORY: /mcserver/custom-world
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WORLD_DIRECTORY
+            value: /mcserver/custom-world
+        documentIndex: 0

--- a/helm/omcsi/values.yaml
+++ b/helm/omcsi/values.yaml
@@ -71,6 +71,10 @@ minecraftWrapper:
     ONLINE_MODE: "true"
     JAVA_OPTS: "-Xmx6G -Xms4G"
     PLUGINS_DIRECTORY: "/mcserver/plugins"
+    # Must match webapp.env.WORLD_DIRECTORY: the webapp lists/deletes worlds under
+    # this path while the wrapper installs uploaded worlds there, so a mismatch
+    # silently hides uploads from the dashboard.
+    WORLD_DIRECTORY: "/mcserver/world"
     # Alert toggles
     ALERTS_SERVER_START: "true"
     ALERTS_SERVER_STOP: "true"

--- a/minecraft-wrapper/src/main/java/com/openmc/minecraftwrapper/service/WorldUploadService.java
+++ b/minecraft-wrapper/src/main/java/com/openmc/minecraftwrapper/service/WorldUploadService.java
@@ -60,18 +60,18 @@ public class WorldUploadService {
             log.info("Server was not running before world upload; proceeding without stop");
         }
 
-        Path tempDir = null;
+        Path stagingDir = null;
         try {
-            tempDir = Files.createTempDirectory("world-upload-");
+            stagingDir = createStagingDirectory(worldDir);
 
             // Single stream open — ZipInputStream validates the ZIP format itself;
             // a non-ZIP payload will throw ZipException from getNextEntry().
             try (InputStream is = file.getInputStream();
                  ZipInputStream zis = new ZipInputStream(is)) {
-                extractZip(zis, tempDir);
+                extractZip(zis, stagingDir);
             }
 
-            Path worldRoot = detectWorldRoot(tempDir);
+            Path worldRoot = detectWorldRoot(stagingDir);
 
             if (!Files.exists(worldRoot.resolve("level.dat"))) {
                 throw new IllegalArgumentException(
@@ -81,13 +81,13 @@ public class WorldUploadService {
             installWorld(worldRoot, worldDir);
             log.info("World replaced successfully at {}", worldDir);
         } finally {
-            if (tempDir != null) {
+            if (stagingDir != null) {
                 try {
-                    if (Files.exists(tempDir)) {
-                        deleteDirectory(tempDir);
+                    if (Files.exists(stagingDir)) {
+                        deleteDirectory(stagingDir);
                     }
                 } catch (IOException e) {
-                    log.debug("Could not clean up temp directory {}: {}", tempDir, e.getMessage());
+                    log.debug("Could not clean up staging directory {}: {}", stagingDir, e.getMessage());
                 }
             }
             if (wasRunning) {
@@ -99,6 +99,37 @@ public class WorldUploadService {
                 }
             }
         }
+    }
+
+    /**
+     * Create the directory the uploaded archive is extracted into.
+     *
+     * <p>The staging directory is deliberately a sibling of the world directory rather than a
+     * {@code java.io.tmpdir} temp directory. {@link #installWorld} finishes by renaming the
+     * extracted world into place, and {@link Files#move} cannot rename a non-empty directory
+     * across filesystems — it fails instead of falling back to copy-and-delete. On both
+     * deployment targets {@code /tmp} and the world volume are separate filesystems (an
+     * {@code emptyDir} vs. the {@code mcserver} PVC on Kubernetes; the container's writable
+     * layer vs. the {@code mcserver} named volume under Docker Compose), so staging under
+     * {@code /tmp} would make every upload of a real world fail. Staging on the world volume
+     * also keeps up to {@link #MAX_UNCOMPRESSED_BYTES} of extracted data off the node's local disk.
+     *
+     * <p>The name is dot-prefixed so the transient directory is visually distinguishable from a
+     * real world; it exists only for the duration of a single upload, during which the server is
+     * stopped.
+     *
+     * @param worldDir absolute, normalized path of the world directory
+     * @return a newly created, empty staging directory on the same filesystem as {@code worldDir}
+     * @throws IOException if the parent directory cannot be created or the staging directory cannot be made
+     */
+    Path createStagingDirectory(Path worldDir) throws IOException {
+        Path parent = worldDir.getParent();
+        if (parent == null) {
+            throw new IOException("World directory '" + worldDir
+                    + "' has no parent directory to stage the upload in");
+        }
+        Files.createDirectories(parent);
+        return Files.createTempDirectory(parent, ".world-upload-");
     }
 
     /**

--- a/minecraft-wrapper/src/test/java/com/openmc/minecraftwrapper/service/WorldUploadServiceTest.java
+++ b/minecraft-wrapper/src/test/java/com/openmc/minecraftwrapper/service/WorldUploadServiceTest.java
@@ -15,6 +15,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -240,6 +243,77 @@ class WorldUploadServiceTest {
 
         Path backup = worldDir.getParent().resolve(worldDir.getFileName() + ".old");
         assertFalse(Files.exists(backup), "Backup directory should be cleaned up after success");
+    }
+
+    // ── createStagingDirectory ───────────────────────────────────────────────
+    //
+    // The staging directory must live on the same filesystem as the world directory:
+    // installWorld finishes with Files.move, which cannot rename a non-empty directory
+    // across filesystems. On both deployment targets /tmp and the world volume are
+    // separate filesystems, so staging under java.io.tmpdir breaks every real upload.
+
+    @Test
+    @DisplayName("createStagingDirectory creates the staging dir alongside the world directory")
+    void stagingDirectoryIsSiblingOfWorldDirectory() throws IOException {
+        Path staging = worldUploadService.createStagingDirectory(worldDir);
+
+        assertEquals(worldDir.getParent(), staging.getParent(),
+                "Staging dir must share a parent (and therefore a filesystem) with the world dir");
+        assertTrue(Files.isDirectory(staging), "Staging dir should have been created");
+    }
+
+    @Test
+    @DisplayName("createStagingDirectory does not stage under java.io.tmpdir")
+    void stagingDirectoryIsNotUnderSystemTempDir() throws IOException {
+        Path systemTmp = Paths.get(System.getProperty("java.io.tmpdir")).toAbsolutePath().normalize();
+        Path isolatedWorldDir = Files.createDirectory(tempDir.resolve("mcserver")).resolve("world");
+        ReflectionTestUtils.setField(worldUploadService, "worldDirectory", isolatedWorldDir.toString());
+
+        Path staging = worldUploadService.createStagingDirectory(isolatedWorldDir).toAbsolutePath().normalize();
+
+        assertNotEquals(systemTmp, staging.getParent(),
+                "Staging dir must not be created directly under java.io.tmpdir");
+        assertEquals(isolatedWorldDir.getParent(), staging.getParent());
+    }
+
+    @Test
+    @DisplayName("createStagingDirectory creates the world's parent directory when it is missing")
+    void stagingDirectoryCreatesMissingParent() throws IOException {
+        Path missingParentWorld = tempDir.resolve("not-yet-created").resolve("world");
+
+        Path staging = worldUploadService.createStagingDirectory(missingParentWorld);
+
+        assertTrue(Files.isDirectory(missingParentWorld.getParent()), "Parent should have been created");
+        assertEquals(missingParentWorld.getParent(), staging.getParent());
+    }
+
+    @Test
+    @DisplayName("replaceWorld leaves no staging directory behind on success")
+    void leavesNoStagingDirectoryOnSuccess() throws IOException {
+        worldUploadService.replaceWorld(zipFile(buildSingleDirWorldZip("myworld")));
+
+        assertEquals(List.of("world"), listDirNames(tempDir),
+                "Only the installed world should remain next to it");
+    }
+
+    @Test
+    @DisplayName("replaceWorld leaves no staging directory behind on failure")
+    void leavesNoStagingDirectoryOnFailure() throws IOException {
+        assertThrows(IllegalArgumentException.class,
+                () -> worldUploadService.replaceWorld(zipFile(buildNoLevelDatZip())));
+
+        assertEquals(List.of(), listDirNames(tempDir),
+                "A failed upload should not leave a staging directory behind");
+    }
+
+    /** Sorted names of the directories directly under {@code dir}. */
+    private List<String> listDirNames(Path dir) throws IOException {
+        try (Stream<Path> entries = Files.list(dir)) {
+            return entries.filter(Files::isDirectory)
+                    .map(p -> p.getFileName().toString())
+                    .sorted()
+                    .toList();
+        }
     }
 
     // ── replaceWorld — server lifecycle ──────────────────────────────────────

--- a/sample.env
+++ b/sample.env
@@ -94,7 +94,9 @@ DASHBOARD_SECONDARY_COLOR=#764ba2
 DASHBOARD_DARK_MODE=true
 # Plugin directory path (default: /mcserver/plugins)
 PLUGINS_DIRECTORY=/mcserver/plugins
-# World directory path (default: /mcserver/world)
+# World directory path (default: /mcserver/world). Shared by the web app, which
+# lists and deletes worlds under this path, and the minecraft-wrapper, which
+# installs uploaded worlds there.
 WORLD_DIRECTORY=/mcserver/world
 
 # CI/CD Plugin Deployment and World Upload Configuration


### PR DESCRIPTION
## Summary

Three correctness fixes, two of them in the world-upload path.

**`minecraft-wrapper`: world uploads failed on every real deployment.**
`WorldUploadService` extracted the uploaded ZIP into a `java.io.tmpdir` temp directory and then installed it with `Files.move`. `Files.move` cannot rename a non-empty directory across filesystems — it fails rather than falling back to copy-and-delete — and `/tmp` is a different filesystem from the world volume on **both** targets: an `emptyDir` vs. the `mcserver` PVC on Kubernetes (`helm/omcsi/templates/minecraft-wrapper.yaml`), and the container's writable overlay layer vs. the `mcserver` named volume under Docker Compose. Every upload of a non-empty world therefore failed at the install step (the `.old` backup was correctly restored, so the server was never left broken — the upload just never landed). Extraction now stages into a sibling directory of the world directory, so the install is a same-filesystem rename. As a side benefit, up to 10 GB of extracted world data no longer transits the node's local disk / container writable layer.

**`WORLD_DIRECTORY` was honoured by the web app but never passed to the wrapper.**
`minecraft-wrapper/src/main/resources/application.properties` reads `world.directory` from `WORLD_DIRECTORY`, but neither `compose.yml` nor the Helm chart set it on the wrapper — only on `webapp`. Overriding it produced a silent split-brain: the dashboard listed and deleted worlds under the configured path while uploads were installed at the hardcoded `/mcserver/world` default, so the uploaded world never appeared in the world list and no error surfaced anywhere. Now wired on both targets.

**`backup-manager`: file-descriptor leak in `calculateDirectorySize`.**
It returned a `Files.walk` pipeline without ever closing the stream, leaking directory handles once for the backups directory plus once per candidate folder on every cleanup pass — i.e. after every scheduled backup. Every other stream-returning NIO call in the file (including `checkSourceDirectoryAvailable` two methods above) already uses try-with-resources; this call site was the outlier.

## Changes

| File | Change |
|---|---|
| `minecraft-wrapper/.../WorldUploadService.java` | New package-private `createStagingDirectory(worldDir)`; `replaceWorld` stages there instead of `java.io.tmpdir` |
| `minecraft-wrapper/.../WorldUploadServiceTest.java` | 5 new tests: staging location, no staging under `java.io.tmpdir`, missing-parent creation, no leftover staging on success/failure |
| `backup-manager/.../BackupService.java` | `Files.walk` wrapped in try-with-resources |
| `compose.yml` | `WORLD_DIRECTORY` added to the `minecraft-wrapper` environment |
| `helm/omcsi/values.yaml` | `minecraftWrapper.env.WORLD_DIRECTORY` added |
| `helm/omcsi/templates/minecraft-wrapper.yaml` | Renders `WORLD_DIRECTORY` into the wrapper container env |
| `helm/omcsi/tests/minecraft_wrapper_test.yaml` | 2 new cases: default renders, override honoured |
| `sample.env` | Comment clarifies the variable is shared by the web app and the wrapper |

## Test plan

Docker Compose / Kubernetes parity checklist (per `CLAUDE.md`):

- [x] `compose.yml` updated — `WORLD_DIRECTORY` on `minecraft-wrapper`
- [x] `sample.env` updated — no new variable; existing entry's comment corrected to describe both consumers
- [x] Helm chart updated — `values.yaml` + `templates/minecraft-wrapper.yaml` carry the equivalent change
- [x] NetworkPolicies — no new inter-service traffic path; no changes needed
- [x] No secrets added to any committed file

Verification run locally:

- [x] `cd minecraft-wrapper && ./gradlew test` — 87 tests, 0 failures (5 new)
- [x] `cd backup-manager && ./gradlew test` — 29 tests, 0 failures
- [x] `compose.yml`, `helm/omcsi/values.yaml`, `helm/omcsi/tests/minecraft_wrapper_test.yaml` parse cleanly, and the rendered `WORLD_DIRECTORY` defaults match between `minecraftWrapper.env` and `webapp.env`
- [ ] `helm lint` / `helm unittest` / `docker compose config` — not runnable in this environment (`helm` and `docker` are unavailable here); delegated to CI, which runs all of them

Closes #214
Closes #215
Closes #216

<!-- gardener-tend-dispatch -->



---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._