### PR TITLE
fix(web-app): wire DEPLOY_AUTH_TOKEN into the webapp and align ALERT_MANAGER_URL across services

### DIFF
--- a/CI-DOCUMENTATION.md
+++ b/CI-DOCUMENTATION.md
@@ -193,7 +193,7 @@ Set the following variables in your omcsi `.env` file (see `sample.env` for refe
 
 | Variable | Description |
 |----------|-------------|
-| `DEPLOY_AUTH_TOKEN` | Shared secret used to authenticate deploy requests. Leave empty to disable the endpoint entirely. |
+| `DEPLOY_AUTH_TOKEN` | Shared secret used to authenticate deploy requests. Leave empty to disable the endpoint entirely. The web app is given the same value and presents it when forwarding a dashboard world upload to the wrapper, so leaving it empty also disables world upload from the dashboard. |
 | `PLUGINS_DIRECTORY` | Absolute path to the Minecraft plugins directory inside the container (default: `/mcserver/plugins`). |
 
 ### Reference Workflow for Spigot Plugin Repositories

--- a/README.md
+++ b/README.md
@@ -830,6 +830,7 @@ See [backup-manager/README.md](backup-manager/README.md) for detailed cron expre
 
 - `ALERT_CONTAINER_NAME`: Alert manager container name (default: `open-mc-alert-manager`)
 - `ALERT_PORT`: Alert manager API port (default: `8090`)
+- `ALERT_MANAGER_URL`: Alerts endpoint the other services POST to (default: `http://alert-manager:8090/api/alerts`). Docker Compose only — one `.env` value shared by minecraft-wrapper, the web app, backup-manager and agent-manager, all of which use it verbatim, so it must include the `/api/alerts` path. On Kubernetes the Helm chart derives it per service from the in-cluster alert-manager Service.
 - `DISCORD_WEBHOOK_URL`: Discord webhook URL for sending notifications (optional)
 - `DISCORD_ENABLED`: Enable/disable Discord notifications (default: `false`)
 

--- a/compose.yml
+++ b/compose.yml
@@ -109,7 +109,8 @@ services:
       - DASHBOARD_DARK_MODE=${DASHBOARD_DARK_MODE:-true}
       - DATA_STORAGE_PATH=${DATA_STORAGE_PATH:-/app/data}
       # Full alerts endpoint. ALERT_MANAGER_URL is a single .env value shared with
-      # minecraft-wrapper and agent-manager, so every consumer must use the same form.
+      # minecraft-wrapper, backup-manager and agent-manager, so every consumer must
+      # use the same form.
       - ALERT_MANAGER_URL=${ALERT_MANAGER_URL:-http://alert-manager:8090/api/alerts}
       - ALERT_MANAGER_ENABLED=${ALERT_MANAGER_ENABLED:-true}
       - MINECRAFT_WRAPPER_URL=${MINECRAFT_WRAPPER_URL:-http://minecraft-wrapper:8092}
@@ -173,6 +174,7 @@ services:
       - BACKUP_MAX_SIZE_MB=${BACKUP_MAX_SIZE_MB:-10240}
       - BACKUP_SCHEDULE=${BACKUP_SCHEDULE:-0 0 2 * * ?}
       # Alert configuration
+      - ALERT_MANAGER_URL=${ALERT_MANAGER_URL:-http://alert-manager:8090/api/alerts}
       - ALERTS_BACKUP_SUCCESS=${ALERTS_BACKUP_SUCCESS:-true}
       - ALERTS_BACKUP_FAILURE=${ALERTS_BACKUP_FAILURE:-true}
 

--- a/compose.yml
+++ b/compose.yml
@@ -108,12 +108,17 @@ services:
       - DASHBOARD_SECONDARY_COLOR=${DASHBOARD_SECONDARY_COLOR:-#764ba2}
       - DASHBOARD_DARK_MODE=${DASHBOARD_DARK_MODE:-true}
       - DATA_STORAGE_PATH=${DATA_STORAGE_PATH:-/app/data}
-      - ALERT_MANAGER_URL=${ALERT_MANAGER_URL:-http://alert-manager:8090}
+      # Full alerts endpoint. ALERT_MANAGER_URL is a single .env value shared with
+      # minecraft-wrapper and agent-manager, so every consumer must use the same form.
+      - ALERT_MANAGER_URL=${ALERT_MANAGER_URL:-http://alert-manager:8090/api/alerts}
       - ALERT_MANAGER_ENABLED=${ALERT_MANAGER_ENABLED:-true}
       - MINECRAFT_WRAPPER_URL=${MINECRAFT_WRAPPER_URL:-http://minecraft-wrapper:8092}
       - MINECRAFT_WRAPPER_ENABLED=${MINECRAFT_WRAPPER_ENABLED:-true}
       - ACCORDION_CHAT_URL=${ACCORDION_CHAT_URL:-}
       - DEPLOYMENT_AUTH_TOKEN=${DEPLOYMENT_AUTH_TOKEN:-}
+      # The webapp authenticates to the wrapper's POST /api/world/upload with this
+      # token, so it needs the same secret the wrapper validates against.
+      - DEPLOY_AUTH_TOKEN=${DEPLOY_AUTH_TOKEN:-}
       - WORLD_DIRECTORY=${WORLD_DIRECTORY:-/mcserver/world}
       # Spring multipart limits. nginx (NGINX_MAX_BODY_SIZE) is the effective cap.
       - MAX_FILE_UPLOAD_SIZE=${MAX_FILE_UPLOAD_SIZE:-2048MB}

--- a/helm/omcsi/templates/webapp.yaml
+++ b/helm/omcsi/templates/webapp.yaml
@@ -115,8 +115,9 @@ spec:
               value: {{ .Values.webapp.env.DASHBOARD_DARK_MODE | quote }}
             - name: DATA_STORAGE_PATH
               value: "/app/data"
+            # Full alerts endpoint, matching minecraft-wrapper/backup-manager/agent-manager.
             - name: ALERT_MANAGER_URL
-              value: "http://{{ include "omcsi.alertManagerHost" . }}:{{ .Values.alertManager.service.port }}"
+              value: "http://{{ include "omcsi.alertManagerHost" . }}:{{ .Values.alertManager.service.port }}/api/alerts"
             - name: ALERT_MANAGER_ENABLED
               value: {{ .Values.webapp.env.ALERT_MANAGER_ENABLED | quote }}
             - name: MINECRAFT_WRAPPER_URL
@@ -136,6 +137,13 @@ spec:
                 secretKeyRef:
                   name: {{ include "omcsi.secretName" . }}
                   key: DEPLOYMENT_AUTH_TOKEN
+            # The webapp authenticates to the wrapper's POST /api/world/upload with this
+            # token, so it needs the same secret the wrapper validates against.
+            - name: DEPLOY_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "omcsi.secretName" . }}
+                  key: DEPLOY_AUTH_TOKEN
           readinessProbe:
             httpGet:
               path: /

--- a/helm/omcsi/tests/minecraft_wrapper_test.yaml
+++ b/helm/omcsi/tests/minecraft_wrapper_test.yaml
@@ -251,3 +251,14 @@ tests:
             name: WORLD_DIRECTORY
             value: /mcserver/custom-world
         documentIndex: 0
+
+  # Every consumer of ALERT_MANAGER_URL POSTs to it verbatim, so all four services must
+  # render the identical full-endpoint form. See the matching assertion in webapp_test.yaml.
+  - it: renders ALERT_MANAGER_URL as the full alerts endpoint
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ALERT_MANAGER_URL
+            value: http://RELEASE-NAME-omcsi-alert-manager:8090/api/alerts
+        documentIndex: 0

--- a/helm/omcsi/tests/webapp_test.yaml
+++ b/helm/omcsi/tests/webapp_test.yaml
@@ -136,3 +136,40 @@ tests:
             name: MAX_REQUEST_UPLOAD_SIZE
             value: "512MB"
         documentIndex: 0
+
+  # The webapp POSTs to ALERT_MANAGER_URL verbatim, exactly like minecraft-wrapper,
+  # backup-manager and agent-manager, so the /api/alerts path must be part of the value.
+  - it: renders ALERT_MANAGER_URL as the full alerts endpoint
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ALERT_MANAGER_URL
+            value: http://RELEASE-NAME-omcsi-alert-manager:8090/api/alerts
+        documentIndex: 0
+
+  # Without this the dashboard cannot authenticate to the wrapper's world upload
+  # endpoint and every upload is rejected as "not configured on this server".
+  - it: renders DEPLOY_AUTH_TOKEN from the chart secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DEPLOY_AUTH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-omcsi-secrets
+                key: DEPLOY_AUTH_TOKEN
+        documentIndex: 0
+
+  - it: still renders DEPLOYMENT_AUTH_TOKEN alongside it
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DEPLOYMENT_AUTH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-omcsi-secrets
+                key: DEPLOYMENT_AUTH_TOKEN
+        documentIndex: 0

--- a/helm/omcsi/values.yaml
+++ b/helm/omcsi/values.yaml
@@ -312,7 +312,11 @@ secrets:
   rconPassword: ""
   adminUsername: "admin"
   adminPassword: ""
+  # Protects the wrapper's POST /api/plugins/deploy and POST /api/world/upload. The webapp
+  # receives the same value and presents it when forwarding a dashboard world upload, so
+  # leaving it empty also disables world upload from the dashboard.
   deployAuthToken: ""
+  # Protects the webapp's POST /api/deployment-history, which the wrapper calls back into.
   deploymentAuthToken: ""
   discordWebhookUrl: ""
   agentDiscordBotToken: ""

--- a/sample.env
+++ b/sample.env
@@ -100,9 +100,12 @@ PLUGINS_DIRECTORY=/mcserver/plugins
 WORLD_DIRECTORY=/mcserver/world
 
 # CI/CD Plugin Deployment and World Upload Configuration
-# Set a strong random secret here to protect the POST /api/plugins/deploy and
-# POST /api/world/upload endpoints. Use the same value as the DEPLOY_AUTH_TOKEN
-# GitHub Actions secret in your plugin repository. Leave empty to disable both endpoints.
+# Set a strong random secret here to protect the minecraft-wrapper's
+# POST /api/plugins/deploy and POST /api/world/upload endpoints. Use the same value as
+# the DEPLOY_AUTH_TOKEN GitHub Actions secret in your plugin repository. Leave empty to
+# disable both endpoints. The web app also receives this token: it presents it when
+# forwarding a dashboard world upload to the wrapper, so leaving it empty disables
+# world upload from the dashboard too.
 DEPLOY_AUTH_TOKEN=
 # Shared secret for the POST /api/deployment-history endpoint on the web app.
 # The minecraft-wrapper sends this token when reporting deployment events.
@@ -140,7 +143,9 @@ BACKUP_SCHEDULE=0 0 2 * * ?
 ALERT_CONTAINER_NAME=open-mc-alert-manager
 # Alert manager API port (default: 8090)
 ALERT_PORT=8090
-# Alert manager API URL for minecraft-wrapper to send alerts (default: http://alert-manager:8090/api/alerts)
+# Alert manager alerts endpoint, shared by minecraft-wrapper, web app, backup-manager and
+# agent-manager (default: http://alert-manager:8090/api/alerts). All of them POST to this
+# value verbatim, so it must include the /api/alerts path.
 ALERT_MANAGER_URL=http://alert-manager:8090/api/alerts
 # Discord webhook URL for notifications (optional)
 # To get a webhook URL: Discord Server Settings → Integrations → Webhooks

--- a/web-app/src/main/java/com/openmc/webapp/service/AlertNotificationService.java
+++ b/web-app/src/main/java/com/openmc/webapp/service/AlertNotificationService.java
@@ -23,7 +23,13 @@ public class AlertNotificationService {
     
     private static final Logger logger = LoggerFactory.getLogger(AlertNotificationService.class);
     
-    @Value("${alert.manager.url:http://alert-manager:8090}")
+    /**
+     * Full alert-manager alerts endpoint, including the {@code /api/alerts} path. This matches
+     * the convention every other consumer of ALERT_MANAGER_URL uses (minecraft-wrapper,
+     * backup-manager, agent-manager, upgrade.sh, resources/post-create.sh) — they all share the
+     * single value from .env, so the web app must not append a path of its own.
+     */
+    @Value("${alert.manager.url:http://alert-manager:8090/api/alerts}")
     private String alertManagerUrl;
     
     @Value("${alert.manager.enabled:true}")
@@ -63,8 +69,7 @@ public class AlertNotificationService {
             
             HttpEntity<Map<String, Object>> request = new HttpEntity<>(alert, headers);
             
-            String url = alertManagerUrl + "/api/alerts";
-            ResponseEntity<String> response = restTemplate.postForEntity(url, request, String.class);
+            ResponseEntity<String> response = restTemplate.postForEntity(alertManagerUrl, request, String.class);
             if (response.getStatusCode().is2xxSuccessful()) {
                 logger.info("Alert sent successfully: {}", title);
             } else {

--- a/web-app/src/main/resources/application.properties
+++ b/web-app/src/main/resources/application.properties
@@ -38,7 +38,9 @@ minecraft.server.plugins-directory=${PLUGINS_DIRECTORY:/mcserver/plugins}
 minecraft.server.world-directory=${WORLD_DIRECTORY:/mcserver/world}
 
 # Alert Manager Configuration
-alert.manager.url=${ALERT_MANAGER_URL:http://alert-manager:8090}
+# Full alerts endpoint, including /api/alerts — ALERT_MANAGER_URL is shared with
+# minecraft-wrapper, backup-manager and agent-manager, which all treat it that way.
+alert.manager.url=${ALERT_MANAGER_URL:http://alert-manager:8090/api/alerts}
 alert.manager.enabled=${ALERT_MANAGER_ENABLED:true}
 
 # Minecraft Wrapper Configuration

--- a/web-app/src/test/java/com/openmc/webapp/controller/ServerControllerTest.java
+++ b/web-app/src/test/java/com/openmc/webapp/controller/ServerControllerTest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
@@ -467,5 +468,30 @@ class ServerControllerTest {
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.error")
                         .value("Invalid request: archive does not contain a level.dat"));
+    }
+
+    // The token comes from DEPLOY_AUTH_TOKEN and must reach the wrapper unchanged — it is the
+    // same secret the wrapper's POST /api/world/upload validates the bearer token against.
+    @Test
+    @DisplayName("Should forward the configured deploy auth token to the wrapper on world upload")
+    void shouldForwardDeployAuthTokenOnWorldUpload() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "world.zip",
+            "application/zip",
+            "test content".getBytes()
+        );
+
+        when(minecraftWrapperService.uploadWorld(any(), anyString()))
+                .thenReturn(WrapperResult.success("World uploaded"));
+
+        mockMvc.perform(multipart("/api/world/upload")
+                        .file(file)
+                        .param("username", "admin")
+                        .param("password", "admin"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        verify(minecraftWrapperService).uploadWorld(any(), eq("test-deploy-token"));
     }
 }

--- a/web-app/src/test/java/com/openmc/webapp/service/AlertNotificationServiceTest.java
+++ b/web-app/src/test/java/com/openmc/webapp/service/AlertNotificationServiceTest.java
@@ -43,7 +43,7 @@ class AlertNotificationServiceTest {
         when(restTemplateBuilder.build()).thenReturn(restTemplate);
 
         alertService = new AlertNotificationService(restTemplateBuilder);
-        ReflectionTestUtils.setField(alertService, "alertManagerUrl", "http://test-alert-manager:8090");
+        ReflectionTestUtils.setField(alertService, "alertManagerUrl", "http://test-alert-manager:8090/api/alerts");
         ReflectionTestUtils.setField(alertService, "alertsEnabled", true);
     }
 
@@ -187,6 +187,25 @@ class AlertNotificationServiceTest {
 
         verify(restTemplate).postForEntity(
                 eq("http://test-alert-manager:8090/api/alerts"),
+                any(),
+                eq(String.class)
+        );
+    }
+
+    // ALERT_MANAGER_URL is one .env value shared with minecraft-wrapper, backup-manager and
+    // agent-manager, all of which POST to it verbatim. Appending a path here would send
+    // dashboard alerts to /api/alerts/api/alerts and 404.
+    @Test
+    @DisplayName("Should post to the configured URL verbatim without appending a path")
+    void shouldPostToConfiguredUrlVerbatim() {
+        ReflectionTestUtils.setField(alertService, "alertManagerUrl", "http://custom-host:9000/custom/alerts");
+        when(restTemplate.postForEntity(anyString(), any(HttpEntity.class), eq(String.class)))
+                .thenReturn(ResponseEntity.ok("Success"));
+
+        alertService.sendAlert("Test Title", "Test Message", "INFO");
+
+        verify(restTemplate).postForEntity(
+                eq("http://custom-host:9000/custom/alerts"),
                 any(),
                 eq(String.class)
         );


### PR DESCRIPTION
Two webapp environment-wiring bugs, both of which silently disable a working feature.

## Summary

**`DEPLOY_AUTH_TOKEN` never reaches the webapp container (#218)**

`ServerController` refuses a dashboard world upload when `deploy.auth.token` is blank, but neither `compose.yml` nor `helm/omcsi/templates/webapp.yaml` ever passed it — only `minecraft-wrapper` got it. An operator who set the token (enabling the wrapper endpoint) still got `World upload is not configured on this server` on every attempt, on both targets.

- `compose.yml`: added `DEPLOY_AUTH_TOKEN` to the `webapp` environment block.
- `helm/omcsi/templates/webapp.yaml`: added a `DEPLOY_AUTH_TOKEN` env entry from the existing `DEPLOY_AUTH_TOKEN` Secret key (the Secret already carried it — `secret.yaml:12`).

**`ALERT_MANAGER_URL` had two incompatible meanings (#219)**

minecraft-wrapper, backup-manager, agent-manager, `upgrade.sh` and `resources/post-create.sh` all POST to `ALERT_MANAGER_URL` verbatim, and `sample.env` ships the full-endpoint form. The web app alone treated it as a base URL and appended `/api/alerts`, so on Docker Compose every dashboard alert went to `/api/alerts/api/alerts` and 404'd — roughly 20 call sites in `ServerController`, failing silently from the user's perspective. Kubernetes was unaffected (the chart computes the value per service), but the templates disagreed for the same reason.

- `AlertNotificationService`: defaults to the full endpoint and POSTs to it verbatim.
- `compose.yml` and `helm/omcsi/templates/webapp.yaml`: both now render the full-endpoint form, matching the other three services.

**Docs**

- `sample.env`: `ALERT_MANAGER_URL` comment now says it is shared by four services and must include the path; `DEPLOY_AUTH_TOKEN` comment notes the web app uses it too.
- `README.md`: documented `ALERT_MANAGER_URL` (it was undocumented).
- `CI-DOCUMENTATION.md` and `helm/omcsi/values.yaml`: clarified the `DEPLOY_AUTH_TOKEN` / `DEPLOYMENT_AUTH_TOKEN` split.

No new inter-service traffic paths — webapp egress to both minecraft-wrapper and alert-manager already exists in `networkpolicies.yaml`, so no NetworkPolicy change was needed.

## Test plan

- [x] `web-app`: `./gradlew test` passes.
- [x] New `AlertNotificationServiceTest` case asserts the configured URL is POSTed verbatim with no path appended (regression guard for #219).
- [x] New `ServerControllerTest` case asserts the configured deploy token is forwarded to the wrapper on world upload.
- [x] New `webapp_test.yaml` cases assert `ALERT_MANAGER_URL` renders the full endpoint and `DEPLOY_AUTH_TOKEN` renders from the chart Secret; new `minecraft_wrapper_test.yaml` case locks the same `ALERT_MANAGER_URL` form so the two cannot drift apart again.
- [x] `compose.yml`, `values.yaml`, and all `helm/omcsi/tests/*.yaml` parse as valid YAML.
- [ ] `helm lint` / `helm unittest` / `docker compose config` — helm and docker are unavailable in this environment; delegated to CI.

### Both-targets checklist

- [x] `compose.yml` updated
- [x] `sample.env` updated
- [x] Helm chart updated (`templates/webapp.yaml`, `values.yaml`)
- [x] NetworkPolicies reviewed — no new traffic paths
- [ ] Live verification on both targets — delegated to CI

Closes #218
Closes #219

<!-- gardener-tend-dispatch -->



---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._