### PR TITLE
feat: support default plugin installation via DEFAULT_PLUGINS env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -767,6 +767,7 @@ Copy `sample.env` to `.env` and modify the following settings:
 - `GAMEMODE`: Default game mode (survival, creative, adventure, spectator)
 - `PVP_ENABLED`: Enable/disable player vs player combat
 - `ONLINE_MODE`: Enable Mojang authentication (set to false for offline/cracked servers)
+- `DEFAULT_PLUGINS`: Comma-separated list of direct download URLs to plugin JARs, installed automatically into `PLUGINS_DIRECTORY` on server setup. A plugin already present there (matched by filename) is left untouched, so it's safe to leave alongside manually or CI-deployed plugins. Leave empty to skip (default).
 
 ### Docker Configuration (for Parallel Servers)
 

--- a/compose.yml
+++ b/compose.yml
@@ -59,6 +59,7 @@ services:
       # Plugin deployment CI/CD configuration
       - DEPLOY_AUTH_TOKEN=${DEPLOY_AUTH_TOKEN:-}
       - PLUGINS_DIRECTORY=${PLUGINS_DIRECTORY:-/mcserver/plugins}
+      - DEFAULT_PLUGINS=${DEFAULT_PLUGINS:-}
       # World directory. Must match the webapp's WORLD_DIRECTORY below: the webapp
       # lists/deletes worlds under this path while the wrapper installs uploaded
       # worlds there, so a mismatch silently hides uploads from the dashboard.

--- a/helm/omcsi/templates/minecraft-wrapper.yaml
+++ b/helm/omcsi/templates/minecraft-wrapper.yaml
@@ -104,6 +104,8 @@ spec:
                   key: DEPLOY_AUTH_TOKEN
             - name: PLUGINS_DIRECTORY
               value: {{ .Values.minecraftWrapper.env.PLUGINS_DIRECTORY | quote }}
+            - name: DEFAULT_PLUGINS
+              value: {{ .Values.minecraftWrapper.env.DEFAULT_PLUGINS | quote }}
             - name: WORLD_DIRECTORY
               value: {{ .Values.minecraftWrapper.env.WORLD_DIRECTORY | quote }}
             - name: WEBAPP_URL

--- a/helm/omcsi/templates/networkpolicies.yaml
+++ b/helm/omcsi/templates/networkpolicies.yaml
@@ -100,7 +100,9 @@ spec:
             matchLabels:
               {{- include "omcsi.selectorLabels" (dict "root" . "component" "webapp") | nindent 14 }}
     # Mojang authentication (online-mode=true) and any other external HTTPS
-    # Required for player login via api.minecraftservices.com / sessionserver.mojang.com
+    # Required for player login via api.minecraftservices.com / sessionserver.mojang.com,
+    # and also covers DEFAULT_PLUGINS downloads (post-create.sh fetches plugin JARs
+    # over HTTPS during server setup).
     - ports:
         - port: 443
           protocol: TCP

--- a/helm/omcsi/tests/minecraft_wrapper_test.yaml
+++ b/helm/omcsi/tests/minecraft_wrapper_test.yaml
@@ -252,6 +252,26 @@ tests:
             value: /mcserver/custom-world
         documentIndex: 0
 
+  - it: DEFAULT_PLUGINS is empty by default
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DEFAULT_PLUGINS
+            value: ""
+        documentIndex: 0
+
+  - it: honours a configured DEFAULT_PLUGINS list
+    set:
+      minecraftWrapper.env.DEFAULT_PLUGINS: "https://example.com/a.jar,https://example.com/b.jar"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DEFAULT_PLUGINS
+            value: "https://example.com/a.jar,https://example.com/b.jar"
+        documentIndex: 0
+
   # Every consumer of ALERT_MANAGER_URL POSTs to it verbatim, so all four services must
   # render the identical full-endpoint form. See the matching assertion in webapp_test.yaml.
   - it: renders ALERT_MANAGER_URL as the full alerts endpoint

--- a/helm/omcsi/values.yaml
+++ b/helm/omcsi/values.yaml
@@ -71,6 +71,11 @@ minecraftWrapper:
     ONLINE_MODE: "true"
     JAVA_OPTS: "-Xmx6G -Xms4G"
     PLUGINS_DIRECTORY: "/mcserver/plugins"
+    # Comma-separated list of direct download URLs to plugin JARs, installed
+    # automatically on server setup. A plugin already present under
+    # PLUGINS_DIRECTORY (matched by filename) is left untouched. Empty by
+    # default.
+    DEFAULT_PLUGINS: ""
     # Must match webapp.env.WORLD_DIRECTORY: the webapp lists/deletes worlds under
     # this path while the wrapper installs uploaded worlds there, so a mismatch
     # silently hides uploads from the dashboard.

--- a/resources/post-create.sh
+++ b/resources/post-create.sh
@@ -114,6 +114,47 @@ setup_server() {
     fi
 }
 
+# Function: Install default plugins listed in DEFAULT_PLUGINS (comma-separated
+# download URLs). Idempotent: a plugin already present under plugins/ (matched
+# by the URL's filename) is left untouched, so manually installed or updated
+# plugins are never overwritten.
+install_default_plugins() {
+    if [ -z "${DEFAULT_PLUGINS:-}" ]; then
+        return 0
+    fi
+
+    mkdir -p "$SERVER_DIR/plugins"
+
+    local IFS=','
+    read -ra plugin_urls <<< "$DEFAULT_PLUGINS"
+    for url in "${plugin_urls[@]}"; do
+        # Trim leading/trailing whitespace
+        url="${url#"${url%%[![:space:]]*}"}"
+        url="${url%"${url##*[![:space:]]}"}"
+        if [ -z "$url" ]; then
+            continue
+        fi
+
+        local filename
+        filename="$(basename "$url")"
+        local dest="$SERVER_DIR/plugins/$filename"
+
+        if [ -f "$dest" ]; then
+            log "Default plugin already installed: $filename"
+            continue
+        fi
+
+        log "Installing default plugin: $filename"
+        if curl -fsSL --max-time 60 -o "$dest" "$url"; then
+            log "Installed default plugin: $filename"
+        else
+            log "WARNING: Failed to download default plugin from $url"
+            rm -f "$dest"
+            send_alert "Default Plugin Install Failed" "Failed to download plugin from $url" "WARNING" "ALERTS_CONFIG_WARNING"
+        fi
+    done
+}
+
 # Function: Setup ops.json file
 setup_ops_file() {
     # Check if ops.json already exists - if so, preserve it to maintain runtime op changes
@@ -248,6 +289,7 @@ start_server() {
 log "Running server setup script..."
 validate_environment
 setup_server
+install_default_plugins
 setup_ops_file
 accept_eula
 create_server_properties

--- a/sample.env
+++ b/sample.env
@@ -94,6 +94,12 @@ DASHBOARD_SECONDARY_COLOR=#764ba2
 DASHBOARD_DARK_MODE=true
 # Plugin directory path (default: /mcserver/plugins)
 PLUGINS_DIRECTORY=/mcserver/plugins
+# Default plugins to install automatically on server setup (optional).
+# Comma-separated list of direct download URLs to plugin JARs. Each is
+# downloaded into PLUGINS_DIRECTORY on startup, keyed by filename, so a
+# plugin that already exists there (installed manually or on a prior boot)
+# is left untouched. Leave empty to skip default plugin installation.
+DEFAULT_PLUGINS=
 # World directory path (default: /mcserver/world). Shared by the web app, which
 # lists and deletes worlds under this path, and the minecraft-wrapper, which
 # installs uploaded worlds there.


### PR DESCRIPTION
<!-- gardener-tend-dispatch -->

## Summary

- Adds a `DEFAULT_PLUGINS` env var: a comma-separated list of direct download URLs to plugin JARs, installed automatically into `PLUGINS_DIRECTORY` on server setup (`resources/post-create.sh`).
- Idempotent by filename — a plugin already present (installed manually, via the CI hot-deploy endpoint, or on a prior boot) is left untouched, so it's safe to combine with other install paths.
- A failed download logs a warning and fires a `ALERTS_CONFIG_WARNING`-gated alert rather than failing server setup.
- Wired into both deployment targets: `compose.yml`/`sample.env` for Docker, `helm/omcsi/values.yaml` + `helm/omcsi/templates/minecraft-wrapper.yaml` for Kubernetes. No new NetworkPolicy rule was needed — the existing "any external HTTPS" egress rule on minecraft-wrapper (originally for Mojang auth) already covers HTTPS plugin downloads; updated its comment to document the new consumer.
- Documented in `README.md` (Server Settings) and `sample.env`.
- Added a `helm unittest` case covering the new env var's default and override rendering.

Closes #13

## Test plan

- [x] Manual review of `resources/post-create.sh` — verified quoting, `set -euo pipefail` interaction with the new `install_default_plugins` function, and the whitespace-trim idiom.
- [x] Manual grep-confirmed the new `DEFAULT_PLUGINS` key exists in both `compose.yml`/`sample.env` and `helm/omcsi/values.yaml`/`helm/omcsi/templates/minecraft-wrapper.yaml`.
- [ ] **UNVERIFIED locally** — this run's sandbox blocks direct execution of `bash`, `shellcheck`, `docker`, and `helm` (all require interactive approval unavailable in this headless dispatch). CI's `validate` job runs `bash -n resources/post-create.sh`, `shellcheck resources/post-create.sh`, and `docker compose config` on this exact diff; the `helm-lint`/`helm-unit-test`/`helm-deploy-test` jobs cover the Helm changes and new unittest case. Treating the CI run on this PR's head SHA as the real anchor — will not merge until it is green.


---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._