### PR TITLE
fix: add upgrade.sh --dry-run and rollback.sh, fix backup path bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,12 @@ jobs:
         bash -n up.sh
         bash -n down.sh
         bash -n upgrade.sh
+        bash -n rollback.sh
         bash -n trigger-backup.sh
         bash -n resources/post-create.sh
-        
+
         echo "🔍 Running ShellCheck linter..."
-        shellcheck up.sh down.sh upgrade.sh trigger-backup.sh resources/post-create.sh scripts/*.sh
+        shellcheck up.sh down.sh upgrade.sh rollback.sh trigger-backup.sh resources/post-create.sh scripts/*.sh
         
     - name: Validate Docker configuration
       run: |

--- a/CI-DOCUMENTATION.md
+++ b/CI-DOCUMENTATION.md
@@ -20,8 +20,8 @@ The main per-PR validation job. It runs the following steps in order:
 
 #### Shell Script Validation
 - **Syntax Checking** (`bash -n`): `up.sh`, `down.sh`, `upgrade.sh`,
-  `trigger-backup.sh`, `resources/post-create.sh`.
-- **ShellCheck Linting**: the same five scripts plus everything under
+  `rollback.sh`, `trigger-backup.sh`, `resources/post-create.sh`.
+- **ShellCheck Linting**: the same six scripts plus everything under
   `scripts/*.sh`.
 
 #### Docker Configuration Validation

--- a/README.md
+++ b/README.md
@@ -849,8 +849,10 @@ The following three toggles are read by `upgrade.sh`, which runs on the Docker h
 `docker compose` directly. They apply to the **Docker Compose deployment only** and have no
 Kubernetes equivalent, so the Helm chart does not expose them:
 - `ALERTS_UPGRADE_START`: Alert when upgrade process begins (default: `true`)
-- `ALERTS_UPGRADE_COMPLETE`: Alert when upgrade completes successfully (default: `true`)
+- `ALERTS_UPGRADE_COMPLETE`: Alert when the upgrade process finishes — either confirmed successful or with startup unverified from logs (default: `true`)
 - `ALERTS_UPGRADE_FAILURE`: Alert when upgrade fails (default: `true`)
+
+`rollback.sh` (also Docker Compose only) sends a completion alert unconditionally — it isn't gated by a toggle, since a rollback is a rare, explicitly-confirmed action.
 
 To enable Discord notifications:
 1. Create a webhook in your Discord server (Server Settings → Integrations → Webhooks)
@@ -953,7 +955,7 @@ See [backup-manager/README.md](backup-manager/README.md) for detailed configurat
 
 #### Manual Backup
 
-The backup-manager service automatically creates backups on a schedule (default: 2 AM daily). Backups are stored in the `./backups/` directory with timestamped names like `backup-20241211-020000`.
+The backup-manager service automatically creates backups on a schedule (default: 2 AM daily). Backups are stored in the `backups` Docker volume (a named volume, not a host directory — see `BACKUPS_VOLUME_NAME` in `.env`) with timestamped names like `backup-20241211-020000`. List them with `./rollback.sh` (no arguments), or directly via `docker run --rm -v backups:/backups:ro alpine ls /backups`.
 
 To trigger a manual backup immediately:
 
@@ -1003,6 +1005,8 @@ This script automates the entire upgrade process:
 - Updates configuration
 - Rebuilds with the new version
 - Starts the server
+
+Preview an upgrade without making any changes with `./upgrade.sh --dry-run` (optionally `./upgrade.sh --dry-run <version>` to skip the version prompt). If an upgrade needs to be undone, `./rollback.sh` restores a previous backup and restarts the server — see [Rollback Procedure](UPGRADE-GUIDE.md#rollback-procedure) in the Upgrade Guide.
 
 ### Upgrade to a New Minecraft Version
 

--- a/README.md
+++ b/README.md
@@ -852,7 +852,7 @@ Kubernetes equivalent, so the Helm chart does not expose them:
 - `ALERTS_UPGRADE_COMPLETE`: Alert when the upgrade process finishes — either confirmed successful or with startup unverified from logs (default: `true`)
 - `ALERTS_UPGRADE_FAILURE`: Alert when upgrade fails (default: `true`)
 
-`rollback.sh` (also Docker Compose only) sends a completion alert unconditionally — it isn't gated by a toggle, since a rollback is a rare, explicitly-confirmed action.
+`rollback.sh` (also Docker Compose only) sends a completion alert on success and an `ERROR` alert if the restore fails partway through, both unconditionally — they aren't gated by a toggle, since a rollback is a rare, explicitly-confirmed action.
 
 To enable Discord notifications:
 1. Create a webhook in your Discord server (Server Settings → Integrations → Webhooks)

--- a/UPGRADE-GUIDE.md
+++ b/UPGRADE-GUIDE.md
@@ -68,6 +68,21 @@ The script will:
 # Script handles the rest automatically
 ```
 
+**Preview a planned upgrade with `--dry-run`:**
+
+Before committing to an upgrade, `--dry-run` shows what the script would do
+without stopping the server, touching `.env`, or creating a backup:
+
+```bash
+./upgrade.sh --dry-run
+# or, non-interactively:
+./upgrade.sh --dry-run 26.2
+```
+
+This prints the current version, target version, current world data size,
+and where the backup would be stored (an existing recent backup, or a new
+one the script would create).
+
 If you prefer manual control or need to understand each step, continue with the manual process below.
 
 ---
@@ -96,17 +111,14 @@ Create a backup of all server data from the persistent volume. This is your safe
 
 #### Option A: Using Backup Manager (Recommended)
 
-The backup-manager service automatically creates scheduled backups (default: 2 AM daily). Before upgrading, ensure a recent backup exists:
+The backup-manager service automatically creates scheduled backups (default: 2 AM daily) into the `backups` Docker volume (a named volume, not a host directory — see `BACKUPS_VOLUME_NAME` in `.env`). Before upgrading, ensure a recent backup exists:
 
 ```bash
-# Check for recent backups
-ls -lth ./backups/
+# List backups in the named volume (also shown by `./rollback.sh` with no args)
+docker run --rm -v backups:/backups:ro alpine sh -c 'ls -lth /backups'
 
-# If no recent backup, restart backup-manager to trigger one
-docker restart open-mc-backup-manager
-
-# Wait a few moments and verify the backup was created
-ls -lth ./backups/
+# If no recent backup, trigger one manually
+./trigger-backup.sh
 ```
 
 **Benefits:**
@@ -169,8 +181,8 @@ docker run --rm \
 **Verify your backup** before proceeding:
 
 ```bash
-# For Option A (backup script)
-ls -lh ./backups/backup-*/mcserver-backup.tar.gz
+# For Option A (backup script) — backups live in the named "backups" volume
+docker run --rm -v backups:/backups:ro alpine sh -c 'ls -lh /backups/backup-*/mcserver-backup.tar.gz'
 
 # For Option B (manual backup)
 ls -lh "$BACKUP_DIR/mcserver-backup.tar.gz"
@@ -275,6 +287,26 @@ Press `Ctrl+C` to stop following the logs (server continues running).
 
 If the upgrade fails or causes issues, you can restore your server from the backup.
 
+### Automated Rollback (Recommended)
+
+`./rollback.sh` automates restoring a backup-manager backup (Option A above)
+from the named `backups` volume: it stops the server, replaces the contents
+of the `mcserver` volume with the chosen backup, and starts the server again.
+
+```bash
+# List available backups (name, size, complete/incomplete)
+./rollback.sh
+
+# Restore a specific backup — the "backup-" prefix is optional
+./rollback.sh 20260115-020000
+```
+
+You'll be asked to type `yes` to confirm before anything is overwritten. Use
+the manual procedure below for Option B/C/D backups (which live in a local
+directory rather than the `backups` volume) or if you need finer control.
+
+### Manual Rollback
+
 ### Step 1: Stop the Server
 
 ```bash
@@ -292,18 +324,18 @@ docker volume rm mcserver
 
 ### Step 3: Restore from Backup
 
-#### If you used Option A (tar.gz backup):
+#### If you used Option A (backup-manager, named volume):
 
 ```bash
-# Specify your backup file
-BACKUP_FILE="./backups/backup-YYYYMMDD-HHMMSS/mcserver-backup.tar.gz"
+# Specify your backup directory name (see: docker run --rm -v backups:/backups:ro alpine ls /backups)
+BACKUP_NAME="backup-YYYYMMDD-HHMMSS"
 
-# Restore the data
+# Restore the data directly from the "backups" volume into the "mcserver" volume
 docker run --rm \
+  --user 1000:1000 \
+  -v backups:/backups:ro \
   -v mcserver:/mcserver \
-  -v "$(pwd)/$(dirname $BACKUP_FILE)":/backup \
-  ubuntu \
-  tar xzf /backup/$(basename $BACKUP_FILE) -C /mcserver
+  alpine sh -c "tar xzf /backups/${BACKUP_NAME}/mcserver-backup.tar.gz -C /mcserver"
 ```
 
 #### If you used Option B (directory backup):

--- a/rollback.sh
+++ b/rollback.sh
@@ -205,15 +205,28 @@ main() {
     echo ""
 
     log_info "Restoring '$backup_name' into volume '$mcserver_volume'..."
-    docker run --rm \
+    # `set -e` inside the container matters: without it, a failed `cd` would
+    # let the following `rm -rf` run against the container's own root instead
+    # of the mounted volume.
+    if ! docker run --rm \
         --user 1000:1000 \
         -v "${backups_volume}:/backups:ro" \
         -v "${mcserver_volume}:/mcserver" \
         alpine sh -c '
+            set -e
             cd /mcserver
             rm -rf -- ..?* .[!.]* * 2>/dev/null || true
             tar xzf "/backups/$1/mcserver-backup.tar.gz" -C /mcserver
-        ' _ "$backup_name"
+        ' _ "$backup_name"; then
+        log_error "Restore failed while extracting '$backup_name'."
+        log_warning "Volume '$mcserver_volume' may now be empty or partially restored."
+        log_info "The server was NOT started. Re-run './rollback.sh $backup_name' once the"
+        log_info "cause is resolved, or restore manually — see UPGRADE-GUIDE.md."
+        send_alert "Server Rollback Failed" \
+            "Restore of '$backup_name' failed; volume '$mcserver_volume' may be in a partial state and the server was not started." \
+            "ERROR"
+        exit 1
+    fi
     log_success "Restore complete."
     echo ""
 

--- a/rollback.sh
+++ b/rollback.sh
@@ -1,0 +1,239 @@
+#!/bin/bash
+set -euo pipefail
+
+# Minecraft Server Rollback Script
+# Restores the server's data volume from a backup created by backup-manager
+# (see UPGRADE-GUIDE.md) and restarts the server. Intended as the automated
+# counterpart to ./upgrade.sh when an upgrade needs to be undone.
+#
+# Usage:
+#   ./rollback.sh                       List available backups and exit.
+#   ./rollback.sh 20260115-020000       Restore backup-20260115-020000.
+#   ./rollback.sh backup-20260115-020000   Same as above (prefix optional).
+
+cd "$(dirname "$0")"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+log_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Function to send an alert to the alert-manager
+send_alert() {
+    local title="$1"
+    local message="$2"
+    local level="${3:-INFO}"
+    local source="rollback-script"
+
+    local alert_url
+    if [ -n "${ALERT_MANAGER_URL:-}" ]; then
+        alert_url="$ALERT_MANAGER_URL"
+    elif [ -f /.dockerenv ] || grep -q docker /proc/1/cgroup 2>/dev/null; then
+        alert_url="http://alert-manager:8090/api/alerts"
+    else
+        alert_url="http://localhost:8090/api/alerts"
+    fi
+
+    if command -v curl >/dev/null 2>&1; then
+        curl -X POST "$alert_url" \
+          -H "Content-Type: application/json" \
+          --max-time 5 \
+          --connect-timeout 5 \
+          -d "{\"title\":\"$title\",\"message\":\"$message\",\"level\":\"$level\",\"source\":\"$source\"}" \
+          >/dev/null 2>&1 || true
+    fi
+}
+
+# Function to load env value
+get_env_value() {
+    local key=$1
+    local default=$2
+    if [ -f .env ]; then
+        grep "^${key}=" .env | cut -d'=' -f2 || echo "$default"
+    else
+        echo "$default"
+    fi
+}
+
+# List backup-* directory names in a named volume, newest first. Backup
+# directory names are zero-padded "backup-yyyyMMdd-HHmmss", so a reverse
+# lexicographic sort is also a reverse chronological sort.
+list_backup_dirs() {
+    local volume=$1
+    docker run --rm -v "${volume}:/backups:ro" alpine sh -c '
+        for d in /backups/backup-*/; do
+            [ -d "$d" ] && basename "$d"
+        done
+    ' 2>/dev/null | sort -r
+}
+
+# True (exit 0) if the given backup directory contains a completed archive.
+backup_is_complete() {
+    local volume=$1
+    local name=$2
+    docker run --rm -v "${volume}:/backups:ro" alpine sh -c \
+        'test -f "/backups/$1/mcserver-backup.tar.gz"' _ "$name" >/dev/null 2>&1
+}
+
+# Human-readable disk usage for a path inside a named volume.
+volume_disk_usage() {
+    local volume=$1
+    local subpath="${2:-}"
+    local out
+    out=$(docker run --rm -v "${volume}:/vol:ro" alpine sh -c \
+        'du -sh "/vol$1" 2>/dev/null' _ "$subpath") || { echo "unknown"; return; }
+    echo "$out" | awk '{print $1}'
+}
+
+print_usage() {
+    cat <<'EOF'
+Usage: ./rollback.sh [backup-name|timestamp]
+
+Restores the Minecraft server's data volume from a previous backup created
+by backup-manager, then restarts the server.
+
+  ./rollback.sh                          List available backups and exit.
+  ./rollback.sh 20260115-020000          Restore the backup-20260115-020000 backup.
+  ./rollback.sh backup-20260115-020000   Same as above (backup- prefix optional).
+
+WARNING: this PERMANENTLY REPLACES the current contents of the server's
+data volume with the chosen backup. The server is stopped before restoring
+and started again afterward.
+EOF
+}
+
+list_available_backups() {
+    local backups_volume=$1
+
+    echo "=========================================="
+    echo "  Available backups (newest first)"
+    echo "=========================================="
+
+    local found=0
+    while IFS= read -r name; do
+        [ -z "$name" ] && continue
+        found=1
+        local size status
+        size=$(volume_disk_usage "$backups_volume" "/$name")
+        if backup_is_complete "$backups_volume" "$name"; then
+            status="complete"
+        else
+            status="incomplete"
+        fi
+        printf '  %-28s %-10s %s\n' "$name" "$size" "$status"
+    done < <(list_backup_dirs "$backups_volume")
+
+    if [ "$found" -eq 0 ]; then
+        log_warning "No backups found in volume '$backups_volume'."
+    fi
+    echo ""
+}
+
+main() {
+    local requested="${1:-}"
+
+    case "$requested" in
+        --help|-h)
+            print_usage
+            exit 0
+            ;;
+    esac
+
+    local backups_volume mcserver_volume
+    backups_volume=$(get_env_value "BACKUPS_VOLUME_NAME" "backups")
+    mcserver_volume=$(get_env_value "VOLUME_NAME" "mcserver")
+
+    if [ -z "$requested" ]; then
+        list_available_backups "$backups_volume"
+        print_usage
+        exit 0
+    fi
+
+    # Normalize to "backup-<timestamp>" and validate the timestamp shape
+    # strictly — this value is later interpolated into a path inside a
+    # container, so it must never contain path separators or shell
+    # metacharacters.
+    local backup_name
+    case "$requested" in
+        backup-*) backup_name="$requested" ;;
+        *) backup_name="backup-$requested" ;;
+    esac
+
+    if ! echo "$backup_name" | grep -qE '^backup-[0-9]{8}-[0-9]{6}$'; then
+        log_error "Invalid backup name/timestamp: '$requested'"
+        log_info "Expected format: YYYYMMDD-HHMMSS (e.g. 20260115-020000)"
+        exit 1
+    fi
+
+    if ! backup_is_complete "$backups_volume" "$backup_name"; then
+        log_error "Backup '$backup_name' not found or incomplete in volume '$backups_volume'."
+        echo ""
+        list_available_backups "$backups_volume"
+        exit 1
+    fi
+
+    echo ""
+    log_warning "This will PERMANENTLY REPLACE the current contents of volume '$mcserver_volume'"
+    log_warning "with the contents of '$backup_name'. This cannot be undone."
+    read -r -p "Type 'yes' to continue: " confirm
+    if [ "$confirm" != "yes" ]; then
+        log_info "Rollback cancelled."
+        exit 0
+    fi
+    echo ""
+
+    log_info "Stopping the server..."
+    ./down.sh
+    echo ""
+
+    log_info "Restoring '$backup_name' into volume '$mcserver_volume'..."
+    docker run --rm \
+        --user 1000:1000 \
+        -v "${backups_volume}:/backups:ro" \
+        -v "${mcserver_volume}:/mcserver" \
+        alpine sh -c '
+            cd /mcserver
+            rm -rf -- ..?* .[!.]* * 2>/dev/null || true
+            tar xzf "/backups/$1/mcserver-backup.tar.gz" -C /mcserver
+        ' _ "$backup_name"
+    log_success "Restore complete."
+    echo ""
+
+    log_info "Starting the server..."
+    ./up.sh
+    echo ""
+
+    local container_name
+    container_name=$(get_env_value "CONTAINER_NAME" "open-mc-server")
+
+    send_alert "Server Rollback Complete" "Restored from backup '$backup_name'." "INFO"
+
+    echo "=========================================="
+    log_success "Rollback to '$backup_name' completed."
+    echo "=========================================="
+    echo ""
+    log_info "Next steps:"
+    echo "  1. Monitor logs: docker logs -f $container_name"
+    echo "  2. Connect to the server and verify everything works"
+    echo ""
+}
+
+main "$@"

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -11,6 +11,7 @@ echo "📝 Checking shell scripts..."
 bash -n up.sh
 bash -n down.sh
 bash -n upgrade.sh
+bash -n rollback.sh
 bash -n trigger-backup.sh
 bash -n resources/post-create.sh
 echo "✅ Shell script syntax validation passed"
@@ -44,6 +45,7 @@ echo "🔐 Checking file permissions..."
 test -x up.sh
 test -x down.sh
 test -x upgrade.sh
+test -x rollback.sh
 test -x trigger-backup.sh
 test -x resources/post-create.sh
 echo "✅ File permissions validation passed"

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -146,7 +146,11 @@ wait_for_server_start() {
         if echo "$logs" | grep -qiE 'Done \([0-9.]+s\)! For help'; then
             return 0
         fi
-        if echo "$logs" | grep -qiE 'failed to bind|exception in server tick loop|could not load|corrupt(ed)? world'; then
+        # Only match indicators that mean the server process itself failed to
+        # come up. Deliberately narrow: a generic phrase like "could not load"
+        # is logged routinely by healthy plugins, and a false positive here
+        # raises a FAILURE alert and exits non-zero on a working upgrade.
+        if echo "$logs" | grep -qiE 'failed to bind to port|exception in server tick loop|failed to start the minecraft server|encountered an unexpected exception|you need to agree to the eula|unable to access jarfile|unsupportedclassversionerror'; then
             return 1
         fi
         sleep "$interval"

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 # Minecraft Server Upgrade Script
 # This script automates the upgrade process for the Minecraft server
 # including backup management and version updates.
+#
+# Usage:
+#   ./upgrade.sh                  Interactive upgrade (prompts for version)
+#   ./upgrade.sh --dry-run        Show the upgrade plan without making changes
+#   ./upgrade.sh --dry-run 26.2   Show the plan for a specific target version
 
 cd "$(dirname "$0")"
 
@@ -81,6 +86,75 @@ get_env_value() {
     fi
 }
 
+# The backups and mcserver volumes are named Docker volumes (not host bind
+# mounts), so backup discovery/inspection has to go through a throwaway
+# container rather than reading a "./backups" path on the host.
+
+# List backup-* directory names in a named volume, newest first. Backup
+# directory names are zero-padded "backup-yyyyMMdd-HHmmss", so a reverse
+# lexicographic sort is also a reverse chronological sort.
+list_backup_dirs() {
+    local volume=$1
+    docker run --rm -v "${volume}:/backups:ro" alpine sh -c '
+        for d in /backups/backup-*/; do
+            [ -d "$d" ] && basename "$d"
+        done
+    ' 2>/dev/null | sort -r
+}
+
+# True (exit 0) if the given backup directory contains a completed archive.
+backup_is_complete() {
+    local volume=$1
+    local name=$2
+    docker run --rm -v "${volume}:/backups:ro" alpine sh -c \
+        'test -f "/backups/$1/mcserver-backup.tar.gz"' _ "$name" >/dev/null 2>&1
+}
+
+# Age of a backup directory in seconds, based on its mtime.
+backup_age_seconds() {
+    local volume=$1
+    local name=$2
+    local mtime
+    mtime=$(docker run --rm -v "${volume}:/backups:ro" alpine sh -c \
+        'stat -c %Y "/backups/$1"' _ "$name" 2>/dev/null) || return 1
+    echo $(( $(date +%s) - mtime ))
+}
+
+# Human-readable disk usage for a path inside a named volume (default: the
+# whole volume). Returns "unknown" if it can't be determined.
+volume_disk_usage() {
+    local volume=$1
+    local subpath="${2:-}"
+    local out
+    out=$(docker run --rm -v "${volume}:/vol:ro" alpine sh -c \
+        'du -sh "/vol$1" 2>/dev/null' _ "$subpath") || { echo "unknown"; return; }
+    echo "$out" | awk '{print $1}'
+}
+
+# Poll `docker logs` for a bounded time looking for a startup success/failure
+# indicator. Returns 0 on confirmed success, 1 on confirmed failure, 2 if
+# inconclusive within max_wait.
+wait_for_server_start() {
+    local container_name=$1
+    local max_wait="${2:-180}"
+    local interval=5
+    local elapsed=0
+    local logs
+
+    while [ "$elapsed" -lt "$max_wait" ]; do
+        logs=$(docker logs "$container_name" --tail 200 2>&1 || true)
+        if echo "$logs" | grep -qiE 'Done \([0-9.]+s\)! For help'; then
+            return 0
+        fi
+        if echo "$logs" | grep -qiE 'failed to bind|exception in server tick loop|could not load|corrupt(ed)? world'; then
+            return 1
+        fi
+        sleep "$interval"
+        elapsed=$((elapsed + interval))
+    done
+    return 2
+}
+
 # Function to check if server is running
 is_server_running() {
     local container_name
@@ -116,6 +190,57 @@ update_env_version() {
     fi
 }
 
+print_usage() {
+    cat <<'EOF'
+Usage: ./upgrade.sh [--dry-run] [VERSION]
+
+  --dry-run   Show the current version, target version, world disk usage,
+              and planned backup location without making any changes.
+  VERSION     Optional target Minecraft version. Prompted for interactively
+              if omitted.
+EOF
+}
+
+# Show the upgrade plan without touching the server, backups, or .env.
+run_dry_run() {
+    local current_version=$1
+    local target_version=$2
+    local backups_volume=$3
+    local mcserver_volume=$4
+
+    if [ -z "$target_version" ]; then
+        read -r -p "Enter the new Minecraft version (e.g., 1.21.10): " target_version
+    fi
+    if [ -z "$target_version" ]; then
+        log_error "No version specified. Aborting dry run."
+        exit 1
+    fi
+
+    echo ""
+    echo "=========================================="
+    echo "  Dry Run — no changes will be made"
+    echo "=========================================="
+    echo ""
+    log_info "Current Minecraft version: $current_version"
+    log_info "Target Minecraft version:  $target_version"
+
+    local world_usage
+    world_usage=$(volume_disk_usage "$mcserver_volume")
+    log_info "Current world data size (volume '$mcserver_volume'): $world_usage"
+
+    local latest_backup
+    latest_backup=$(list_backup_dirs "$backups_volume" | head -1)
+    if [ -n "$latest_backup" ] && backup_is_complete "$backups_volume" "$latest_backup"; then
+        log_info "Existing backup would be reused: $latest_backup (volume '$backups_volume')"
+    else
+        log_info "No valid existing backup found — a new one would be created via trigger-backup.sh"
+    fi
+    log_info "Planned backup location: volume '$backups_volume', directory backup-<timestamp>/mcserver-backup.tar.gz"
+
+    echo ""
+    log_info "No changes were made (dry run)."
+}
+
 # Main upgrade process
 main() {
     echo "=========================================="
@@ -133,12 +258,25 @@ main() {
     
     # Get current version
     current_version=$(get_current_version)
+
+    local backups_volume mcserver_volume
+    backups_volume=$(get_env_value "BACKUPS_VOLUME_NAME" "backups")
+    mcserver_volume=$(get_env_value "VOLUME_NAME" "mcserver")
+
+    if [ "$DRY_RUN" = true ]; then
+        run_dry_run "$current_version" "$TARGET_VERSION_ARG" "$backups_volume" "$mcserver_volume"
+        exit 0
+    fi
+
     log_info "Current Minecraft version: $current_version"
     echo ""
-    
+
     # Prompt for new version
-    read -r -p "Enter the new Minecraft version (e.g., 1.21.10): " new_version
-    
+    local new_version="$TARGET_VERSION_ARG"
+    if [ -z "$new_version" ]; then
+        read -r -p "Enter the new Minecraft version (e.g., 1.21.10): " new_version
+    fi
+
     if [ -z "$new_version" ]; then
         log_error "No version specified. Aborting."
         exit 1
@@ -162,50 +300,49 @@ main() {
     # Step 1: Ensure backup exists
     log_info "Step 1/6: Checking for backup..."
     
-    # Check if a recent backup exists (within last 60 minutes)
-    recent_backup=$(find ./backups -maxdepth 1 -type d -name "backup-*" -mmin -60 2>/dev/null | head -1)
-    
-    if [ -n "$recent_backup" ] && [ -f "$recent_backup/mcserver-backup.tar.gz" ]; then
-        log_info "Using recent backup: $recent_backup"
-        backup_dir="$recent_backup"
-    else
-        log_info "No recent backup found, checking for any existing backup..."
-        backup_dir=$(find ./backups -maxdepth 1 -type d -name "backup-*" -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -1 | cut -d' ' -f2-)
-        
-        if [ -z "$backup_dir" ] || [ ! -f "$backup_dir/mcserver-backup.tar.gz" ]; then
-            log_warning "No valid backup found. Creating a new backup..."
-            
-            # Check if trigger-backup.sh exists
-            if [ ! -f ./trigger-backup.sh ]; then
-                log_error "trigger-backup.sh script not found!"
-                log_info "Please ensure trigger-backup.sh is available to create a backup."
-                exit 1
-            fi
-            
-            # Trigger a new backup (while services are still running)
-            log_info "Running trigger-backup.sh to create a backup before upgrade..."
-            echo ""
-            if ! ./trigger-backup.sh; then
-                log_error "Backup creation failed! Cannot proceed with upgrade without a backup."
-                exit 1
-            fi
-            echo ""
-            
-            # Get the most recent backup that was just created
-            backup_dir=$(find ./backups -maxdepth 1 -type d -name "backup-*" -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -1 | cut -d' ' -f2-)
-            
-            if [ -z "$backup_dir" ] || [ ! -f "$backup_dir/mcserver-backup.tar.gz" ]; then
-                log_error "Backup creation succeeded but backup file not found!"
-                exit 1
-            fi
-            
-            log_success "Backup created successfully: $backup_dir"
+    # Backups live in the named "backups" Docker volume, so discovery goes
+    # through a throwaway container rather than a host "./backups" path.
+    backup_dir=$(list_backup_dirs "$backups_volume" | head -1)
+
+    if [ -n "$backup_dir" ] && backup_is_complete "$backups_volume" "$backup_dir"; then
+        local age
+        age=$(backup_age_seconds "$backups_volume" "$backup_dir" || echo 999999)
+        if [ "$age" -le 3600 ]; then
+            log_info "Using recent backup: $backup_dir"
         else
             log_info "Using existing backup: $backup_dir"
         fi
+    else
+        log_warning "No valid backup found. Creating a new backup..."
+
+        # Check if trigger-backup.sh exists
+        if [ ! -f ./trigger-backup.sh ]; then
+            log_error "trigger-backup.sh script not found!"
+            log_info "Please ensure trigger-backup.sh is available to create a backup."
+            exit 1
+        fi
+
+        # Trigger a new backup (while services are still running)
+        log_info "Running trigger-backup.sh to create a backup before upgrade..."
+        echo ""
+        if ! ./trigger-backup.sh; then
+            log_error "Backup creation failed! Cannot proceed with upgrade without a backup."
+            exit 1
+        fi
+        echo ""
+
+        # Get the most recent backup that was just created
+        backup_dir=$(list_backup_dirs "$backups_volume" | head -1)
+
+        if [ -z "$backup_dir" ] || ! backup_is_complete "$backups_volume" "$backup_dir"; then
+            log_error "Backup creation succeeded but backup file not found!"
+            exit 1
+        fi
+
+        log_success "Backup created successfully: $backup_dir"
     fi
-    
-    log_success "Backup verified: $backup_dir"
+
+    log_success "Backup verified: $backup_dir (volume '$backups_volume')"
     echo ""
     
     # Step 2: Stop the server
@@ -248,12 +385,13 @@ main() {
     
     # Step 6: Monitor startup
     log_info "Step 6/6: Monitoring server startup..."
-    log_info "Waiting for server to initialize..."
-    sleep 5
-    
+
     local container_name
     container_name=$(get_env_value "CONTAINER_NAME" "open-mc-server")
-    
+
+    local start_status=0
+    wait_for_server_start "$container_name" 180 || start_status=$?
+
     # Show recent logs
     echo ""
     log_info "Recent server logs:"
@@ -261,30 +399,58 @@ main() {
     docker logs "$container_name" --tail 20 2>&1 || log_warning "Could not retrieve logs"
     echo "----------------------------------------"
     echo ""
-    
+
     # Final summary
     echo "=========================================="
-    log_success "Upgrade completed successfully!"
-    send_alert "Server Upgrade Complete" "Successfully upgraded from $current_version to $new_version. Backup: $backup_dir" "INFO" "ALERTS_UPGRADE_COMPLETE"
+    if [ "$start_status" -eq 1 ]; then
+        log_error "Server logs indicate the upgrade may have failed to start!"
+        send_alert "Server Upgrade Failed" "Upgrade from $current_version to $new_version rebuilt and started, but logs indicate a startup failure. Backup: $backup_dir" "ERROR" "ALERTS_UPGRADE_FAILURE"
+    elif [ "$start_status" -eq 2 ]; then
+        log_warning "Could not confirm successful startup from logs within 180s — check manually."
+        send_alert "Server Upgrade Unverified" "Upgrade from $current_version to $new_version rebuilt and started, but startup could not be confirmed from logs. Backup: $backup_dir" "WARNING" "ALERTS_UPGRADE_COMPLETE"
+    else
+        log_success "Upgrade completed successfully!"
+        send_alert "Server Upgrade Complete" "Successfully upgraded from $current_version to $new_version. Backup: $backup_dir" "INFO" "ALERTS_UPGRADE_COMPLETE"
+    fi
     echo "=========================================="
     echo ""
     log_info "Summary:"
     echo "  - Previous version: $current_version"
     echo "  - New version: $new_version"
-    echo "  - Backup location: $backup_dir"
+    echo "  - Backup location: $backup_dir (volume '$backups_volume')"
     echo ""
-    local container_name
-    container_name=$(get_env_value "CONTAINER_NAME" "open-mc-server")
     log_info "Next steps:"
     echo "  1. Monitor logs: docker logs -f $container_name"
     echo "  2. Connect to the server and verify everything works"
     echo "  3. Check that plugins are compatible with the new version"
     echo ""
     log_info "If you encounter issues:"
+    echo "  - Run ./rollback.sh $backup_dir to restore this backup"
     echo "  - See the rollback procedure in UPGRADE-GUIDE.md"
-    echo "  - Your backup is available at: $backup_dir"
     echo ""
+
+    if [ "$start_status" -eq 1 ]; then
+        exit 1
+    fi
 }
+
+# Parse command-line arguments
+DRY_RUN=false
+TARGET_VERSION_ARG=""
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run)
+            DRY_RUN=true
+            ;;
+        --help|-h)
+            print_usage
+            exit 0
+            ;;
+        *)
+            TARGET_VERSION_ARG="$arg"
+            ;;
+    esac
+done
 
 # Run main function
 main


### PR DESCRIPTION
## Summary

- **Fixes a real bug**: `upgrade.sh` assumed backups live in a host `./backups` directory, but `compose.yml` has stored them in a named Docker volume (`backups`) since #156. Backup discovery (`find ./backups ...`) has therefore always found nothing on a real host, and every upgrade run would eventually fail with `Backup creation succeeded but backup file not found!` even after a successful backup. Backup discovery/inspection now goes through a throwaway `alpine` container against the named volume instead of a host path.
- **`upgrade.sh --dry-run [VERSION]`**: shows current version, target version, current world disk usage, and the planned backup location without stopping the server, touching `.env`, or creating a backup.
- **Startup verification**: after rebuild + start, the script now polls `docker logs` for up to 180s for a success/failure indicator instead of a fixed 5s sleep, and reports/alerts accordingly (success / startup failure / inconclusive).
- **New `rollback.sh <timestamp>`**: lists available backups (name/size/complete-or-not) with no args, or restores a specific backup into the `mcserver` volume and restarts the server, with a typed `yes` confirmation before anything is overwritten.
- `UPGRADE-GUIDE.md` and `README.md` corrected to describe the named `backups` Docker volume (instead of the nonexistent host path) and document `--dry-run` / `rollback.sh`.
- `scripts/ci-local.sh`, `.github/workflows/ci.yml`, and `CI-DOCUMENTATION.md` updated so `rollback.sh` gets the same `bash -n` + shellcheck coverage as the other lifecycle scripts.

These scripts are Docker Compose-only lifecycle tooling (same as the existing `ALERTS_UPGRADE_*` toggles they reuse) — no Kubernetes/Helm equivalent exists or is needed, consistent with the existing README callout that these toggles apply to Compose only.

## Verification

- `bash -n upgrade.sh` / `bash -n rollback.sh` — pass (via `python3 subprocess`, see note below).
- `shellcheck up.sh down.sh upgrade.sh rollback.sh trigger-backup.sh resources/post-create.sh scripts/*.sh` — pass, no warnings.
- **Docker itself is not available in this sandbox** (no daemon reachable), so the actual `docker run`/`docker compose` code paths in `upgrade.sh` and `rollback.sh` could not be executed end-to-end here. This mirrors the pre-existing situation for `upgrade.sh` (CI has never executed it live either — `ci-local.sh`/`ci.yml` only check syntax/lint/permissions). Marking this **UNVERIFIED for live-Docker execution**; CI (which does have a Docker daemon) will confirm `docker compose config` still parses, a manual smoke test (`./upgrade.sh --dry-run`, then `./rollback.sh` against a real backup) is recommended before merging, given this touches destructive data-restore logic.
- No Gradle modules touched.

## Test plan
- [ ] CI green (shellcheck, `bash -n`, `docker compose config`, Gradle module tests — unaffected)
- [ ] Manual: `./upgrade.sh --dry-run` against a real `.env`/volume shows sane output
- [ ] Manual: `./rollback.sh` (no args) lists real backups from the `backups` volume
- [ ] Manual: `./rollback.sh <timestamp>` restores and restarts correctly

Closes #11

<!-- gardener-tend-dispatch -->


---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._