### PR TITLE
feat: publish Helm chart to GHCR OCI registry

### DIFF
--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -1,0 +1,44 @@
+name: Publish Helm Chart
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'helm/omcsi/Chart.yaml'
+      - '.github/workflows/helm-publish.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Package and publish to GHCR
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: 'v3.17.0'
+
+      - name: Lint chart
+        run: helm lint helm/omcsi --set secrets.rconPassword=x --set secrets.adminPassword=x
+
+      - name: Package chart
+        id: package
+        run: |
+          helm package helm/omcsi --destination /tmp/helm-package
+          version=$(grep '^version:' helm/omcsi/Chart.yaml | awk '{print $2}')
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "path=/tmp/helm-package/omcsi-${version}.tgz" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io --username ${{ github.actor }} --password-stdin
+
+      - name: Push chart to GHCR
+        run: helm push "${{ steps.package.outputs.path }}" oci://ghcr.io/${{ github.repository_owner }}/charts

--- a/README.md
+++ b/README.md
@@ -92,6 +92,16 @@ helm upgrade omcsi ./helm/omcsi --namespace omcsi --reuse-values
 helm uninstall omcsi --namespace omcsi
 ```
 
+**Installing without cloning the repo**
+
+The chart is also published as an OCI artifact on every `helm/omcsi/Chart.yaml` version bump (see [`.github/workflows/helm-publish.yml`](.github/workflows/helm-publish.yml)), so it can be installed directly without a local checkout:
+```bash
+helm install omcsi oci://ghcr.io/dmccoystephenson/charts/omcsi --version 0.1.0 \
+  --namespace omcsi --create-namespace \
+  --set secrets.rconPassword=changeme \
+  --set secrets.adminPassword=strongpassword
+```
+
 The chart exposes most application-level `sample.env` variables through `values.yaml`. Some values are intentionally computed or fixed in the templates (e.g., internal service URLs are derived from Helm helpers, RCON port references are sourced from `minecraftWrapper.internalService.rconPort`, and `DATA_STORAGE_PATH` is hardcoded to match the PVC mount). Docker Compose-only variables like container names and host port mappings are excluded — Kubernetes manages those natively. See [`helm/omcsi/values.yaml`](helm/omcsi/values.yaml) for the full list of configurable values including image tags, replica counts, resource requests/limits, storage classes, service types, and feature flags.
 
 **Key design notes:**

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ helm install omcsi oci://ghcr.io/dmccoystephenson/charts/omcsi --version 0.1.0 \
   --set secrets.adminPassword=strongpassword
 ```
 
+Note: GHCR packages are private on first publish. The package's visibility must be switched to public once (repo → Packages → `omcsi` → Package settings → Change visibility) before anonymous `helm install`/`helm pull` from the `oci://` URL will work; until then, run `helm registry login ghcr.io` with a token that has `read:packages`.
+
 The chart exposes most application-level `sample.env` variables through `values.yaml`. Some values are intentionally computed or fixed in the templates (e.g., internal service URLs are derived from Helm helpers, RCON port references are sourced from `minecraftWrapper.internalService.rconPort`, and `DATA_STORAGE_PATH` is hardcoded to match the PVC mount). Docker Compose-only variables like container names and host port mappings are excluded — Kubernetes manages those natively. See [`helm/omcsi/values.yaml`](helm/omcsi/values.yaml) for the full list of configurable values including image tags, replica counts, resource requests/limits, storage classes, service types, and feature flags.
 
 **Key design notes:**

--- a/docs/KUBERNETES_IMPROVEMENTS.md
+++ b/docs/KUBERNETES_IMPROVEMENTS.md
@@ -129,14 +129,14 @@ All three PDBs use `policy/v1` (stable since Kubernetes 1.21).
 
 ---
 
-## 10. Helm Chart Publishing
+## 10. ~~Helm Chart Publishing~~ ✅ Resolved
 
 **Problem:** The chart is only available from the Git repository. Operators must clone the repo or reference the chart path directly.
 
-**Suggested improvements:**
-- Publish the chart to a Helm repository (e.g., GitHub Pages via `chart-releaser-action`, or an OCI registry).
-- Add a CI job that packages and publishes the chart on tagged releases.
-- Update README install instructions to support `helm install omcsi oci://ghcr.io/dmccoystephenson/omcsi` or similar.
+**Implemented in PR #TBD:**
+- Added `.github/workflows/helm-publish.yml`, which lints, packages, and pushes the chart to `oci://ghcr.io/dmccoystephenson/charts/omcsi` whenever `helm/omcsi/Chart.yaml` changes on `main` (or via manual `workflow_dispatch`).
+- README documents `helm install omcsi oci://ghcr.io/dmccoystephenson/charts/omcsi --version <chart-version>` as an alternative to cloning the repo.
+- The local-path install (`./helm/omcsi`) continues to work unchanged for all deployment flows.
 
 **Priority:** Low — convenience improvement; the current `./helm/omcsi` path works for all deployment flows.
 

--- a/docs/KUBERNETES_IMPROVEMENTS.md
+++ b/docs/KUBERNETES_IMPROVEMENTS.md
@@ -133,7 +133,7 @@ All three PDBs use `policy/v1` (stable since Kubernetes 1.21).
 
 **Problem:** The chart is only available from the Git repository. Operators must clone the repo or reference the chart path directly.
 
-**Implemented in PR #TBD:**
+**Implemented in PR #224:**
 - Added `.github/workflows/helm-publish.yml`, which lints, packages, and pushes the chart to `oci://ghcr.io/dmccoystephenson/charts/omcsi` whenever `helm/omcsi/Chart.yaml` changes on `main` (or via manual `workflow_dispatch`).
 - README documents `helm install omcsi oci://ghcr.io/dmccoystephenson/charts/omcsi --version <chart-version>` as an alternative to cloning the repo.
 - The local-path install (`./helm/omcsi`) continues to work unchanged for all deployment flows.

--- a/docs/KUBERNETES_IMPROVEMENTS.md
+++ b/docs/KUBERNETES_IMPROVEMENTS.md
@@ -137,8 +137,7 @@ All three PDBs use `policy/v1` (stable since Kubernetes 1.21).
 - Added `.github/workflows/helm-publish.yml`, which lints, packages, and pushes the chart to `oci://ghcr.io/dmccoystephenson/charts/omcsi` whenever `helm/omcsi/Chart.yaml` changes on `main` (or via manual `workflow_dispatch`).
 - README documents `helm install omcsi oci://ghcr.io/dmccoystephenson/charts/omcsi --version <chart-version>` as an alternative to cloning the repo.
 - The local-path install (`./helm/omcsi`) continues to work unchanged for all deployment flows.
-
-**Priority:** Low — convenience improvement; the current `./helm/omcsi` path works for all deployment flows.
+- The chart is only republished when `Chart.yaml`'s `version` is bumped, so template changes must be accompanied by a version bump to reach the registry.
 
 ---
 
@@ -185,5 +184,5 @@ All three PDBs use `policy/v1` (stable since Kubernetes 1.21).
 | 7 | Horizontal Pod Autoscaler | Low | Low |
 | 8 | ~~Network policies~~ ✅ Resolved | ~~Low~~ | ~~Medium~~ |
 | 9 | ~~Pod Disruption Budgets~~ ✅ Resolved | ~~Low~~ | ~~Low~~ |
-| 10 | Helm chart publishing | Low | Low |
+| 10 | ~~Helm chart publishing~~ ✅ Resolved | ~~Low~~ | ~~Low~~ |
 | 11 | ~~Monitoring and observability~~ ✅ Resolved | ~~Low~~ | ~~Medium~~ |


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/helm-publish.yml`, which lints, packages, and pushes the `helm/omcsi` chart to `oci://ghcr.io/dmccoystephenson/charts/omcsi` whenever `helm/omcsi/Chart.yaml` changes on `main` (or via manual `workflow_dispatch`), following the same trigger/permissions pattern as the existing `docker-publish.yml` workflow.
- Documents the resulting `helm install omcsi oci://ghcr.io/dmccoystephenson/charts/omcsi --version <chart-version>` install path in the README as an alternative to cloning the repo — the local `./helm/omcsi` path is unchanged.
- Documents that GHCR packages are private on first publish, so the package's visibility must be switched to public once (by hand) before anonymous `helm install`/`helm pull` from the `oci://` URL works.
- Marks item 10 in `docs/KUBERNETES_IMPROVEMENTS.md` as resolved — both the section heading and the Summary table row — following the existing "Resolved" section convention (see item 11).

## Why
Closes #151 — the chart was previously only installable by cloning the repo and referencing the local path.

## Test plan
- [x] All 7 CI checks green on `618888a`: `Validate Code and Configuration`, `Helm Unit Tests`, `Helm Deploy Smoke Test`, `Terraform Validate`, `Security Scanning`, `Trivy`, `Test Minecraft Server Run`
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/helm-publish.yml'))"` — YAML syntax valid
- [x] Confirmed `helm/omcsi/Chart.yaml` declares no `dependencies:`, so `helm package` needs no preceding `helm dependency update`
- [x] Confirmed the packaged artifact path assumed by the workflow (`omcsi-0.1.0.tgz`) matches chart name/version, and that `grep '^version:'` correctly anchors past `appVersion:`
- [x] Diff review against the established `docker-publish.yml` conventions (trigger `paths:`, `workflow_dispatch`, minimal `permissions:`, step naming)
- [x] Docs pass: no workflow-index document exists in this repo, so adding a workflow introduces no doc drift; `terraform/COST_ANALYSIS.md`'s `docker-publish.yml` mention is an ARM-platform note, not an index
- [ ] **UNVERIFIED locally** — `helm` and `shellcheck` are unavailable in the sandbox this PR was authored from, so `helm lint`, `helm unittest`, `docker compose config`, and `scripts/ci-local.sh` could not be run locally. This PR does not touch `compose.yml`, `sample.env`, or any Helm template — only a new standalone publish workflow and docs — so no deployment-target parity gap is introduced. The PR's own CI run (`ci.yml`'s `helm-lint`/`helm-unit-test`/`helm-deploy-test` jobs, all green) is the anchor for chart correctness.

## Note on the workflow's first run
The new `helm-publish.yml` workflow will not fire on this PR (it triggers on `push` to `main` only), but `.github/workflows/helm-publish.yml` is itself in its trigger `paths:`, so **merging this PR fires it immediately** and publishes chart `0.1.0` — the merge is therefore the anchor for the push step. Note that the first publish lands as a *private* GHCR package; its visibility must be switched to public once by hand before the documented anonymous `helm install oci://...` works (see the README note added in `618888a`).

Closes #151

<!-- gardener-tend-dispatch -->



---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._