### PR TITLE
test: add coverage for alert-manager and backup-manager GlobalExceptionHandler

### DIFF
--- a/alert-manager/src/test/java/com/openmc/alertmanager/exception/GlobalExceptionHandlerTest.java
+++ b/alert-manager/src/test/java/com/openmc/alertmanager/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,93 @@
+package com.openmc.alertmanager.exception;
+
+import jakarta.validation.ConstraintViolationException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("GlobalExceptionHandler Tests")
+class GlobalExceptionHandlerTest {
+
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+    @Test
+    @DisplayName("Should return 400 with generic message for method argument validation errors")
+    void shouldHandleValidationErrors() {
+        MethodArgumentNotValidException ex = mock(MethodArgumentNotValidException.class);
+
+        ResponseEntity<Map<String, Object>> response = handler.handleValidationErrors(ex);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("Validation failed", response.getBody().get("message"));
+        assertEquals(400, response.getBody().get("status"));
+        assertEquals("Bad Request", response.getBody().get("error"));
+        assertNotNull(response.getBody().get("timestamp"));
+    }
+
+    @Test
+    @DisplayName("Should return 400 with the violation message for constraint violations")
+    void shouldHandleConstraintViolation() {
+        ConstraintViolationException ex = new ConstraintViolationException("field must not be blank", Collections.emptySet());
+
+        ResponseEntity<Map<String, Object>> response = handler.handleConstraintViolation(ex);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("field must not be blank", response.getBody().get("message"));
+    }
+
+    @Test
+    @DisplayName("Should return 400 with generic message for handler method validation errors")
+    void shouldHandleHandlerMethodValidation() {
+        HandlerMethodValidationException ex = mock(HandlerMethodValidationException.class);
+
+        ResponseEntity<Map<String, Object>> response = handler.handleHandlerMethodValidation(ex);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("Validation failed", response.getBody().get("message"));
+    }
+
+    @Test
+    @DisplayName("Should return 500 with the exception message for alert processing failures")
+    void shouldHandleAlertException() {
+        AlertException ex = new AlertException("failed to send alert");
+
+        ResponseEntity<Map<String, Object>> response = handler.handleAlertException(ex);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertEquals("failed to send alert", response.getBody().get("message"));
+        assertEquals(500, response.getBody().get("status"));
+    }
+
+    @Test
+    @DisplayName("Should return 400 with a fixed message for malformed request bodies")
+    void shouldHandleHttpMessageNotReadable() {
+        HttpMessageNotReadableException ex = mock(HttpMessageNotReadableException.class);
+
+        ResponseEntity<Map<String, Object>> response = handler.handleHttpMessageNotReadable(ex);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("Malformed request body", response.getBody().get("message"));
+    }
+
+    @Test
+    @DisplayName("Should return 500 with a fixed message and hide details for unexpected exceptions")
+    void shouldHandleGenericException() {
+        RuntimeException ex = new RuntimeException("some internal secret detail");
+
+        ResponseEntity<Map<String, Object>> response = handler.handleGenericException(ex);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertEquals("An unexpected error occurred", response.getBody().get("message"));
+        assertFalse(response.getBody().get("message").toString().contains("secret"));
+    }
+}

--- a/backup-manager/src/test/java/com/openmc/backupmanager/exception/GlobalExceptionHandlerTest.java
+++ b/backup-manager/src/test/java/com/openmc/backupmanager/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,93 @@
+package com.openmc.backupmanager.exception;
+
+import jakarta.validation.ConstraintViolationException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("GlobalExceptionHandler Tests")
+class GlobalExceptionHandlerTest {
+
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+    @Test
+    @DisplayName("Should return 500 with the exception message for backup operation failures")
+    void shouldHandleBackupException() {
+        BackupException ex = new BackupException("failed to create backup archive");
+
+        ResponseEntity<Map<String, Object>> response = handler.handleBackupException(ex);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertEquals("failed to create backup archive", response.getBody().get("message"));
+        assertEquals(500, response.getBody().get("status"));
+    }
+
+    @Test
+    @DisplayName("Should return 400 with a fixed message for method argument validation errors")
+    void shouldHandleValidationErrors() {
+        MethodArgumentNotValidException ex = mock(MethodArgumentNotValidException.class);
+
+        ResponseEntity<Map<String, Object>> response = handler.handleValidationErrors(ex);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("Validation failed", response.getBody().get("message"));
+        assertEquals(400, response.getBody().get("status"));
+        assertEquals("Bad Request", response.getBody().get("error"));
+        assertNotNull(response.getBody().get("timestamp"));
+    }
+
+    @Test
+    @DisplayName("Should return 400 with the violation message for constraint violations")
+    void shouldHandleConstraintViolation() {
+        ConstraintViolationException ex = new ConstraintViolationException("field must not be blank", Collections.emptySet());
+
+        ResponseEntity<Map<String, Object>> response = handler.handleConstraintViolation(ex);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("field must not be blank", response.getBody().get("message"));
+    }
+
+    @Test
+    @DisplayName("Should return 400 with a fixed message for handler method validation errors")
+    void shouldHandleHandlerMethodValidation() {
+        HandlerMethodValidationException ex = mock(HandlerMethodValidationException.class);
+
+        ResponseEntity<Map<String, Object>> response = handler.handleHandlerMethodValidation(ex);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("Validation failed", response.getBody().get("message"));
+    }
+
+    @Test
+    @DisplayName("Should return 400 with a fixed message for malformed request bodies")
+    void shouldHandleHttpMessageNotReadable() {
+        HttpMessageNotReadableException ex = mock(HttpMessageNotReadableException.class);
+
+        ResponseEntity<Map<String, Object>> response = handler.handleHttpMessageNotReadable(ex);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("Malformed request body", response.getBody().get("message"));
+    }
+
+    @Test
+    @DisplayName("Should return 500 with a fixed message and hide details for unexpected exceptions")
+    void shouldHandleGenericException() {
+        RuntimeException ex = new RuntimeException("some internal secret detail");
+
+        ResponseEntity<Map<String, Object>> response = handler.handleGenericException(ex);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertEquals("An unexpected error occurred", response.getBody().get("message"));
+        assertFalse(response.getBody().get("message").toString().contains("secret"));
+    }
+}


### PR DESCRIPTION
## Summary

- Stage B (unit-test expansion) cycle: no open issue in the backlog was appropriately scoped for this cycle (see Triage notes below), so this cycle adds regression coverage for previously untested, behavior-bearing code instead.
- Adds `GlobalExceptionHandlerTest` for both `alert-manager` and `backup-manager`. Neither class had any test coverage anywhere in the repo, and CI's `validate` job does not build or test either module (only `web-app`, `minecraft-wrapper`, `agent-manager`), making this code doubly at risk of silent regressions.
- Each test class exercises all six `@ExceptionHandler` methods (validation errors, constraint violations, handler-method validation, the module's domain exception, malformed request bodies, and the generic fallback), asserting HTTP status and response body message/status/error fields.
- Characterization tests only — no production code was changed.

## Triage notes

All currently open issues (#15, #50, #65, #73, #114, #182, #183) are either:
- Too large for this cycle's scope ceiling (#182, #183 are explicitly staged multi-PR efforts; #73 spans backend + web UI changes),
- Blocked pending human authorization (#65 asks for a `my-agent.md` agent-configuration file, which falls under this loop's harness-blocked "agent-loaded config" rule), or
- Ambiguous to re-attempt (#114: a prior, fully-implemented Copilot PR for this exact issue — #117, branch `copilot/implement-role-based-access` — went through multiple review rounds and was closed without a stated reason rather than merged. Re-implementing from scratch risks duplicating work the repo owner may have deliberately declined; left open for human decision rather than guessed at).

No issue is closed by this PR.

## Test plan

- [x] `(cd alert-manager && ./gradlew test --no-daemon)` — full suite passes, including the new `GlobalExceptionHandlerTest`
- [x] `(cd backup-manager && ./gradlew test --no-daemon)` — full suite passes, including the new `GlobalExceptionHandlerTest`
- [ ] Full `./scripts/ci-local.sh` — the harness's non-interactive sandbox denies the shell-execution permission needed to run this script (and even `bash -n <script>`) without an interactive approval, so it could not be run locally this cycle. This PR touches only new test files (no shell scripts, `compose.yml`, or `sample.env`), so the parts of `ci-local.sh` outside the two `./gradlew test` runs above are out of scope for this change; the GitHub Actions `validate` job on this PR's head commit is the authoritative anchor.

<!-- gardener-tend-dispatch -->


---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._