### PR TITLE
test: add coverage for BackupMapper

### DIFF
--- a/backup-manager/src/test/java/com/openmc/backupmanager/mapper/BackupMapperTest.java
+++ b/backup-manager/src/test/java/com/openmc/backupmanager/mapper/BackupMapperTest.java
@@ -1,0 +1,71 @@
+package com.openmc.backupmanager.mapper;
+
+import com.openmc.backupmanager.dto.LatestBackupResponse;
+import com.openmc.backupmanager.service.BackupService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("BackupMapper Tests")
+class BackupMapperTest {
+
+    private BackupMapper backupMapper;
+
+    @BeforeEach
+    void setUp() {
+        backupMapper = Mappers.getMapper(BackupMapper.class);
+    }
+
+    @Test
+    @DisplayName("Should map a successful backup status to a response")
+    void shouldMapSuccessfulBackupStatusToResponse() {
+        BackupService.LatestBackupStatus status = new BackupService.LatestBackupStatus(
+                true, "2024-01-01T02:00:00Z", "/backups/backup-20240101-020000",
+                "Minecraft server backup created successfully.");
+
+        LatestBackupResponse response = backupMapper.toLatestBackupResponse(status);
+
+        assertTrue(response.isAvailable());
+        assertTrue(response.getSuccess());
+        assertEquals("2024-01-01T02:00:00Z", response.getTimestamp());
+        assertEquals("/backups/backup-20240101-020000", response.getBackupPath());
+        assertEquals("Minecraft server backup created successfully.", response.getMessage());
+    }
+
+    @Test
+    @DisplayName("Should map a failed backup status to a response without a backup path")
+    void shouldMapFailedBackupStatusToResponse() {
+        BackupService.LatestBackupStatus status = new BackupService.LatestBackupStatus(
+                false, "2024-01-01T02:05:00Z", null, "Backup failed: volume not found");
+
+        LatestBackupResponse response = backupMapper.toLatestBackupResponse(status);
+
+        assertTrue(response.isAvailable());
+        assertFalse(response.getSuccess());
+        assertEquals("2024-01-01T02:05:00Z", response.getTimestamp());
+        assertNull(response.getBackupPath());
+        assertEquals("Backup failed: volume not found", response.getMessage());
+    }
+
+    @Test
+    @DisplayName("Should always set available to true regardless of status content")
+    void shouldAlwaysSetAvailableToTrue() {
+        BackupService.LatestBackupStatus status = new BackupService.LatestBackupStatus(
+                false, null, null, null);
+
+        LatestBackupResponse response = backupMapper.toLatestBackupResponse(status);
+
+        assertTrue(response.isAvailable());
+    }
+
+    @Test
+    @DisplayName("Should return null when the status is null")
+    void shouldReturnNullWhenStatusIsNull() {
+        LatestBackupResponse response = backupMapper.toLatestBackupResponse(null);
+
+        assertNull(response);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a unit test class for `BackupMapper`, the MapStruct mapper used by `BackupController` to convert `BackupService.LatestBackupStatus` into `LatestBackupResponse`.
- The mapper's generated implementation (`BackupMapperImpl`) previously had zero direct coverage — `BackupControllerTest` mocks `BackupMapper` entirely, so the real generated mapping logic (including the hardcoded `available = true` constant) was never exercised.
- Tests cover: successful status mapping, failed status mapping (null `backupPath`), the `available` constant always being `true`, and the null-source-returns-null case (default MapStruct behavior).

This is a **Stage B (unit-test expansion)** cycle per the dev-loop skill — the open-issue backlog (#183, #182, #114, #73, #65, #50, #15) is all large, ambiguous-scope feature work not suited to a single coherent PR, so this cycle instead targeted a small, real coverage gap. `alert-manager`'s `AlertController` was initially suspected as untested but on closer inspection already has full coverage from PR #225 — `backup-manager`'s `BackupMapper` was the actual gap found.

No tracking issue — gap found during triage.

## Test plan
- [x] `(cd backup-manager && ./gradlew compileJava compileTestJava --no-daemon)` — PASS
- [x] `(cd backup-manager && ./gradlew test --no-daemon)` — PASS, all 4 new `BackupMapperTest` cases pass alongside the existing suite
- [x] No `compose.yml`/`sample.env`/`helm/` changes — dual-deployment-target checklist and NetworkPolicy checks are not applicable (test-only change)
- [ ] Repo-wide `scripts/ci-local.sh` — UNVERIFIED-not-applicable: `docker` is not invokable in this sandbox, and this PR touches no Docker/Helm config, so the anchor is out of scope for this change. `backup-manager`'s own `./gradlew test` (run above) is the actual anchor for the module CI does not cover (CI's `validate` job never runs `alert-manager`/`backup-manager` tests).

<!-- gardener-tend-dispatch -->


---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._