### PR TITLE
docs: list all five Gradle modules in CI troubleshooting section

### DIFF
--- a/CI-DOCUMENTATION.md
+++ b/CI-DOCUMENTATION.md
@@ -243,7 +243,8 @@ The workflow:
 
 ### Java Module Build / Test Failures
 - Run `./gradlew build` and `./gradlew test` locally inside the affected
-  module (`web-app`, `minecraft-wrapper`, or `agent-manager`) to reproduce.
+  module (`web-app`, `minecraft-wrapper`, `agent-manager`, `alert-manager`,
+  or `backup-manager`) to reproduce.
 - Confirm you're on JDK 21 — older or newer JDKs may produce class-version
   errors that look unrelated.
 


### PR DESCRIPTION
## Summary

- `CI-DOCUMENTATION.md`'s "Java Module Build / Test Failures" troubleshooting step only named `web-app`, `minecraft-wrapper`, and `agent-manager` as the modules to reproduce failures in locally, even though `.github/workflows/ci.yml`'s `validate` job (and `scripts/ci-local.sh`) build and test all five Gradle modules — `alert-manager` and `backup-manager` were missing from this one section, despite being listed correctly everywhere else in the same doc (the module list, the "What Gets Checked" section, etc.)
- Result of this cycle's Stage A documentation accuracy sweep (Phase 2) across `README.md`, `CLAUDE.md`, `CONTRIBUTING.md`, `CI-DOCUMENTATION.md`, `SELF-HOSTING.md`, and `sample.env`. This was the only drift found — the rest of the sweep (port tables, env var cross-references, CI job descriptions) checked out accurate against source.
- Also filed #227 for a separate, harness-blocked drift found during the sweep: `CLAUDE.md`'s "Adding a New Service" step 4 describes a per-service `helm/omcsi/templates/<service>/` subdirectory layout, but the chart actually uses flat files (`helm/omcsi/templates/minecraft-wrapper.yaml`, etc.). Editing `CLAUDE.md` is agent-loaded config and requires human review, so it's tracked as an issue rather than fixed in this PR.

## Test plan

- [x] Docs-only change — verified by re-reading `.github/workflows/ci.yml` and `scripts/ci-local.sh`, which both list all five modules (`web-app`, `minecraft-wrapper`, `agent-manager`, `alert-manager`, `backup-manager`)
- [x] No code/config touched — CI anchor (build/test suites) not applicable to this change

Closes nothing directly (no tracking issue existed for this specific line); #227 filed separately for the CLAUDE.md drift found in the same sweep.

<!-- gardener-tend-dispatch -->


---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._