### PR TITLE
test: cover remaining GlobalExceptionHandlers and PlayerProfileMapper

### DIFF
--- a/minecraft-wrapper/src/test/java/com/openmc/minecraftwrapper/exception/GlobalExceptionHandlerTest.java
+++ b/minecraft-wrapper/src/test/java/com/openmc/minecraftwrapper/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,137 @@
+package com.openmc.minecraftwrapper.exception;
+
+import jakarta.validation.ConstraintViolationException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("GlobalExceptionHandler Tests")
+class GlobalExceptionHandlerTest {
+
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+    @Test
+    @DisplayName("Should return 400 with generic message for method argument validation errors")
+    void shouldHandleValidationErrors() {
+        MethodArgumentNotValidException ex = mock(MethodArgumentNotValidException.class);
+
+        ResponseEntity<Map<String, Object>> response = handler.handleValidationErrors(ex);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("Validation failed", response.getBody().get("message"));
+        assertEquals(400, response.getBody().get("status"));
+        assertEquals("Bad Request", response.getBody().get("error"));
+        assertNotNull(response.getBody().get("timestamp"));
+    }
+
+    @Test
+    @DisplayName("Should return 400 with the violation message for constraint violations")
+    void shouldHandleConstraintViolation() {
+        ConstraintViolationException ex = new ConstraintViolationException("message must not be blank", Collections.emptySet());
+
+        ResponseEntity<Map<String, Object>> response = handler.handleConstraintViolation(ex);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("message must not be blank", response.getBody().get("message"));
+    }
+
+    @Test
+    @DisplayName("Should return 400 with a fixed message for malformed request bodies")
+    void shouldHandleHttpMessageNotReadable() {
+        HttpMessageNotReadableException ex = mock(HttpMessageNotReadableException.class);
+
+        ResponseEntity<Map<String, Object>> response = handler.handleHttpMessageNotReadable(ex);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("Malformed request body", response.getBody().get("message"));
+    }
+
+    @Test
+    @DisplayName("Should return 400 with generic message for handler method validation errors")
+    void shouldHandleHandlerMethodValidation() {
+        HandlerMethodValidationException ex = mock(HandlerMethodValidationException.class);
+
+        ResponseEntity<Map<String, Object>> response = handler.handleHandlerMethodValidation(ex);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("Validation failed", response.getBody().get("message"));
+    }
+
+    @Test
+    @DisplayName("Should return 400 with the exception message for invalid arguments")
+    void shouldHandleIllegalArgument() {
+        IllegalArgumentException ex = new IllegalArgumentException("Plugin name must not contain path separators");
+
+        ResponseEntity<Map<String, Object>> response = handler.handleIllegalArgument(ex);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("Plugin name must not contain path separators", response.getBody().get("message"));
+        assertEquals(400, response.getBody().get("status"));
+    }
+
+    @Test
+    @DisplayName("Should return 409 with the exception message for invalid server state")
+    void shouldHandleIllegalState() {
+        IllegalStateException ex = new IllegalStateException("Server is already running");
+
+        ResponseEntity<Map<String, Object>> response = handler.handleIllegalState(ex);
+
+        assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
+        assertEquals("Server is already running", response.getBody().get("message"));
+        assertEquals(409, response.getBody().get("status"));
+        assertEquals("Conflict", response.getBody().get("error"));
+    }
+
+    @Test
+    @DisplayName("Should return 500 with a fixed message and hide details for I/O errors")
+    void shouldHandleIOException() {
+        IOException ex = new IOException("/mcserver/plugins/secret-path denied");
+
+        ResponseEntity<Map<String, Object>> response = handler.handleIOException(ex);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertEquals("An I/O error occurred", response.getBody().get("message"));
+        assertEquals(500, response.getBody().get("status"));
+        assertFalse(response.getBody().get("message").toString().contains("secret-path"));
+    }
+
+    @Test
+    @DisplayName("Should return 500 with a fixed message and hide details for unexpected exceptions")
+    void shouldHandleGenericException() {
+        RuntimeException ex = new RuntimeException("some internal secret detail");
+
+        ResponseEntity<Map<String, Object>> response = handler.handleGenericException(ex);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertEquals("An unexpected error occurred", response.getBody().get("message"));
+        assertFalse(response.getBody().get("message").toString().contains("secret"));
+    }
+
+    @Test
+    @DisplayName("Should build every error body with the same ordered set of keys")
+    void shouldBuildConsistentErrorBody() {
+        List<Map<String, Object>> bodies = new ArrayList<>();
+        bodies.add(handler.handleIllegalArgument(new IllegalArgumentException("bad")).getBody());
+        bodies.add(handler.handleIllegalState(new IllegalStateException("conflict")).getBody());
+        bodies.add(handler.handleIOException(new IOException("io")).getBody());
+        bodies.add(handler.handleGenericException(new RuntimeException("boom")).getBody());
+
+        for (Map<String, Object> body : bodies) {
+            assertNotNull(body);
+            assertIterableEquals(List.of("timestamp", "status", "error", "message"), body.keySet());
+        }
+    }
+}

--- a/web-app/src/test/java/com/openmc/webapp/exception/GlobalExceptionHandlerTest.java
+++ b/web-app/src/test/java/com/openmc/webapp/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,98 @@
+package com.openmc.webapp.exception;
+
+import jakarta.validation.ConstraintViolationException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("GlobalExceptionHandler Tests")
+class GlobalExceptionHandlerTest {
+
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+    @Test
+    @DisplayName("Should return 400 with generic message for method argument validation errors")
+    void shouldHandleValidationErrors() {
+        MethodArgumentNotValidException ex = mock(MethodArgumentNotValidException.class);
+
+        ResponseEntity<Map<String, Object>> response = handler.handleValidationErrors(ex);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("Validation failed", response.getBody().get("message"));
+        assertEquals(400, response.getBody().get("status"));
+        assertEquals("Bad Request", response.getBody().get("error"));
+        assertNotNull(response.getBody().get("timestamp"));
+    }
+
+    @Test
+    @DisplayName("Should return 400 with the violation message for constraint violations")
+    void shouldHandleConstraintViolation() {
+        ConstraintViolationException ex = new ConstraintViolationException("command must not be blank", Collections.emptySet());
+
+        ResponseEntity<Map<String, Object>> response = handler.handleConstraintViolation(ex);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("command must not be blank", response.getBody().get("message"));
+    }
+
+    @Test
+    @DisplayName("Should return 400 with generic message for handler method validation errors")
+    void shouldHandleHandlerMethodValidation() {
+        HandlerMethodValidationException ex = mock(HandlerMethodValidationException.class);
+
+        ResponseEntity<Map<String, Object>> response = handler.handleHandlerMethodValidation(ex);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("Validation failed", response.getBody().get("message"));
+    }
+
+    @Test
+    @DisplayName("Should return 400 with a fixed message for malformed request bodies")
+    void shouldHandleHttpMessageNotReadable() {
+        HttpMessageNotReadableException ex = mock(HttpMessageNotReadableException.class);
+
+        ResponseEntity<Map<String, Object>> response = handler.handleHttpMessageNotReadable(ex);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("Malformed request body", response.getBody().get("message"));
+    }
+
+    @Test
+    @DisplayName("Should return 500 with a fixed message and hide details for unexpected exceptions")
+    void shouldHandleGenericException() {
+        RuntimeException ex = new RuntimeException("rcon password was hunter2");
+
+        ResponseEntity<Map<String, Object>> response = handler.handleGenericException(ex);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertEquals("An unexpected error occurred", response.getBody().get("message"));
+        assertEquals(500, response.getBody().get("status"));
+        assertEquals("Internal Server Error", response.getBody().get("error"));
+        assertFalse(response.getBody().get("message").toString().contains("hunter2"));
+    }
+
+    @Test
+    @DisplayName("Should build every error body with the same ordered set of keys")
+    void shouldBuildConsistentErrorBody() {
+        Map<String, Object> clientError = handler
+                .handleConstraintViolation(new ConstraintViolationException("bad", Collections.emptySet()))
+                .getBody();
+        Map<String, Object> serverError = handler.handleGenericException(new RuntimeException("boom")).getBody();
+
+        assertNotNull(clientError);
+        assertNotNull(serverError);
+        assertIterableEquals(List.of("timestamp", "status", "error", "message"), clientError.keySet());
+        assertIterableEquals(List.of("timestamp", "status", "error", "message"), serverError.keySet());
+    }
+}

--- a/web-app/src/test/java/com/openmc/webapp/mapper/PlayerProfileMapperTest.java
+++ b/web-app/src/test/java/com/openmc/webapp/mapper/PlayerProfileMapperTest.java
@@ -1,0 +1,65 @@
+package com.openmc.webapp.mapper;
+
+import com.openmc.webapp.model.LeaderboardEntry;
+import com.openmc.webapp.model.PlayerProfile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("PlayerProfileMapper Tests")
+class PlayerProfileMapperTest {
+
+    private PlayerProfileMapper playerProfileMapper;
+
+    @BeforeEach
+    void setUp() {
+        playerProfileMapper = Mappers.getMapper(PlayerProfileMapper.class);
+    }
+
+    @Test
+    @DisplayName("Should map every leaderboard entry field to the player profile")
+    void shouldMapLeaderboardEntryToPlayerProfile() {
+        LeaderboardEntry entry = new LeaderboardEntry(
+                "0d2d0f0a-1b2c-4d3e-8f90-abcdef123456", "Notch", 42.5, 17);
+
+        PlayerProfile profile = playerProfileMapper.toPlayerProfile(entry);
+
+        assertNotNull(profile);
+        assertEquals("0d2d0f0a-1b2c-4d3e-8f90-abcdef123456", profile.getPlayerUuid());
+        assertEquals("Notch", profile.getPlayerName());
+        assertEquals(42.5, profile.getHoursPlayed());
+        assertEquals(17, profile.getTotalLogins());
+    }
+
+    @Test
+    @DisplayName("Should leave leaderboardRank unset so the caller can assign the real rank")
+    void shouldNotPopulateLeaderboardRank() {
+        LeaderboardEntry entry = new LeaderboardEntry("uuid", "Steve", 1.0, 1);
+
+        PlayerProfile profile = playerProfileMapper.toPlayerProfile(entry);
+
+        assertEquals(0, profile.getLeaderboardRank());
+    }
+
+    @Test
+    @DisplayName("Should map an entry with default values without failing")
+    void shouldMapEmptyEntry() {
+        PlayerProfile profile = playerProfileMapper.toPlayerProfile(new LeaderboardEntry());
+
+        assertNotNull(profile);
+        assertNull(profile.getPlayerUuid());
+        assertNull(profile.getPlayerName());
+        assertEquals(0.0, profile.getHoursPlayed());
+        assertEquals(0, profile.getTotalLogins());
+        assertEquals(0, profile.getLeaderboardRank());
+    }
+
+    @Test
+    @DisplayName("Should return null when the entry is null")
+    void shouldReturnNullWhenEntryIsNull() {
+        assertNull(playerProfileMapper.toPlayerProfile(null));
+    }
+}


### PR DESCRIPTION
<!-- gardener-tend-dispatch -->

## Summary

Test-only change. Fills the three coverage gaps left after #225 and #226:

- **`minecraft-wrapper` `GlobalExceptionHandler`** — was entirely untested (nothing under `minecraft-wrapper/src/test/` referenced it). Covers all eight handlers, notably `IllegalStateException` → **409 Conflict** (how the wrapper signals "server already running") and `IOException` → 500 with the raw message suppressed.
- **`web-app` `GlobalExceptionHandler`** — same gap. Covers all five handlers, including the deliberate asymmetry where `ConstraintViolationException` echoes the exception message but the catch-all `Exception` handler does not.
- **`web-app` `PlayerProfileMapper`** — was only ever injected as a Mockito mock in the three `ActivityTrackerService` tests, so the generated `PlayerProfileMapperImpl` never executed. Now exercised via `Mappers.getMapper(...)`, matching `BackupMapperTest` from #226, including the assertion that `leaderboardRank` stays `0` because `ActivityTrackerService` assigns the real rank after mapping.

Both new handler tests also assert the shared `buildErrorBody` contract — the `timestamp`/`status`/`error`/`message` keys in `LinkedHashMap` insertion order.

## Test plan

- [x] `cd minecraft-wrapper && ./gradlew build && ./gradlew test` — green; new `GlobalExceptionHandlerTest` reports 9 tests, 0 failures.
- [x] `cd web-app && ./gradlew build && ./gradlew test` — green; 223 tests total, 0 failures (new `GlobalExceptionHandlerTest` 6, `PlayerProfileMapperTest` 4).
- [x] No Docker/Kubernetes work needed: this PR adds only `src/test/java` files. `compose.yml`, `sample.env`, `helm/omcsi/`, and `terraform/` are untouched, so neither deployment target changes.
- [ ] `helm lint` / `helm unittest` / `docker compose config` / `./scripts/ci-local.sh` — **not run locally**; these tools are permission-blocked in this environment. Delegated to GitHub Actions CI, which runs them on this PR.

Closes #229
Closes #230
Closes #231



---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._