### PR TITLE
fix: ignore local values-override.yaml so Helm secrets are not committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Environment variables
 .env
 
+# Local Helm value overrides (hold real secrets; see CLAUDE.md)
+values-override.yaml
+values-override.yml
+
 # IDE files
 .idea/
 .vscode/


### PR DESCRIPTION
## Summary

- `values-override.yaml` and `values-override.yml` are now ignored by git.
- `CLAUDE.md` (lines 10, 75, and 123) directs Kubernetes credentials to be supplied through "a gitignored `values-override.yaml`", but no such entry existed in `.gitignore` — the only credential-bearing pattern present was `.env`. The documented workflow therefore produced an untracked-but-not-ignored file at the repo root that `git add .` would have staged.
- The values consumed by `helm/omcsi/templates/secret.yaml` and covered by this file include `secrets.rconPassword`, `secrets.adminPassword`, `secrets.deployAuthToken`, `secrets.deploymentAuthToken`, `secrets.discordWebhookUrl`, `secrets.agentDiscordBotToken`, `secrets.agentDiscordChannelId`, and `secrets.agentAnthropicApiKey`.
- Exact filenames are matched rather than a `values-*.yaml` wildcard, so the chart's own tracked `helm/omcsi/values.yaml` is deliberately left alone.

## Test plan

- [x] `git check-ignore -v values-override.yaml values-override.yml helm/omcsi/values.yaml sample.env` — the two override filenames match the new rules; `helm/omcsi/values.yaml` and `sample.env` are not matched.
- [x] No currently tracked file becomes ignored by this change (no path in the repository is named `values-override.yaml`/`.yml`).
- [x] Deployment-target parity is unaffected: no service, config, environment variable, volume, or network path is changed, so neither `compose.yml`/`sample.env` nor `helm/omcsi/` requires an accompanying edit.
- [ ] CI (`Validate Code and Configuration`, `Helm Unit Tests`, `Helm Deploy Smoke Test`, `Terraform Validate`, `Security Scanning`) green.

Closes #237

<!-- gardener-tend-dispatch -->

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).