### PR TITLE
docs: correct CLAUDE.md drift in structure table, helm lint, and service steps

### DIFF
--- a/CI-DOCUMENTATION.md
+++ b/CI-DOCUMENTATION.md
@@ -53,7 +53,10 @@ in sync when a module is added or removed.
 - Confirms `LICENSE` is present.
 
 #### Helm Chart Linting
-- Sets up Helm and runs `helm lint helm/omcsi` against the chart.
+- Sets up Helm and runs `helm lint helm/omcsi --set secrets.rconPassword=ci
+  --set secrets.adminPassword=ci` against the chart. The two `--set` values are
+  required: `templates/secret.yaml` wraps them in `required` and they default to
+  `""` in `values.yaml`, so lint fails without them.
 
 ### 2. Helm Unit Tests (`helm-unit-test`)
 
@@ -249,7 +252,9 @@ The workflow:
   errors that look unrelated.
 
 ### Helm Lint / Unit Test Failures
-- `helm lint helm/omcsi` reproduces lint output locally.
+- `helm lint helm/omcsi --set secrets.rconPassword=ci --set secrets.adminPassword=ci`
+  reproduces lint output locally. Omitting the `--set` flags produces a
+  `secrets.rconPassword is required` error rather than real lint findings.
 - `helm unittest helm/omcsi` reproduces template assertions; look at
   `helm/omcsi/tests/*.yaml` for which template a failing assertion belongs to.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ Checklist for any PR touching services, config, or infrastructure:
 | `terraform/linode/` | Terraform config that provisions LKE and deploys the Helm chart |
 | `terraform/aws/` | Terraform config that provisions a VPC and EKS cluster and deploys the Helm chart |
 | `terraform/existing-cluster/` | Terraform config that deploys the Helm chart into a cluster you already run, configured from a supplied kubeconfig path/context |
-| `terraform/modules/` | Shared modules (`omcsi-helm`, `traefik`) consumed by the targets above |
+| `terraform/modules/` | Shared modules (`omcsi-helm`, `traefik`) consumed by the `linode`, `aws`, and `existing-cluster` targets. `hetzner` does not use them — it runs `helm upgrade` over SSH on the node instead. |
 | `<service>/` | One directory per service (source code, Dockerfile) |
 | `scripts/ci-local.sh` | Local CI validation script |
 
@@ -92,7 +92,8 @@ kubectl logs -n omcsi <pod>  # check for startup errors
 
 CI runs `fmt -check -diff`, `init -backend=false`, and `validate` against **all four**
 targets — `linode`, `aws`, `existing-cluster`, `hetzner` — on every PR. Because
-`terraform/modules/` is shared, editing one target can break another, so check each:
+`terraform/modules/` is shared by `linode`, `aws`, and `existing-cluster`, editing
+one of those targets can break another, so check each:
 
 ```bash
 for t in linode aws existing-cluster hetzner; do

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,9 @@ Checklist for any PR touching services, config, or infrastructure:
 | `helm/omcsi/` | Helm chart for Kubernetes deployment |
 | `terraform/hetzner/` | Terraform config that provisions one Hetzner server, self-manages a single-node kubeadm cluster on it (cloud-init), and deploys the Helm chart — the cheapest cloud target (~$14/mo). Deploys via SSH from the node (not the Helm provider) since a kubeadm node has no API credentials as resource attributes at plan time. |
 | `terraform/linode/` | Terraform config that provisions LKE and deploys the Helm chart |
+| `terraform/aws/` | Terraform config that provisions a VPC and EKS cluster and deploys the Helm chart |
+| `terraform/existing-cluster/` | Terraform config that deploys the Helm chart into a cluster you already run, configured from a supplied kubeconfig path/context |
+| `terraform/modules/` | Shared modules (`omcsi-helm`, `traefik`) consumed by the targets above |
 | `<service>/` | One directory per service (source code, Dockerfile) |
 | `scripts/ci-local.sh` | Local CI validation script |
 
@@ -65,13 +68,17 @@ docker compose logs --tail=50 <service>   # check for startup errors
 
 ### Kubernetes / Helm
 ```bash
-# Lint the chart
-helm lint helm/omcsi
+# Lint the chart. secrets.rconPassword and secrets.adminPassword are `required`
+# in templates/secret.yaml and default to "", so lint fails without them —
+# this is the exact invocation CI uses.
+helm lint helm/omcsi --set secrets.rconPassword=ci --set secrets.adminPassword=ci
 
 # Run unit tests (validates templates, NetworkPolicies, etc.)
 helm unittest helm/omcsi
 
-# Dry-run render to catch template errors
+# Dry-run render to catch template errors. values-override.yaml is a local,
+# gitignored file — drop the flag (and pass the two --set values above) if you
+# do not have one.
 helm template omcsi helm/omcsi --values values-override.yaml
 
 # Apply to a cluster
@@ -81,12 +88,26 @@ kubectl get pods -n omcsi   # all pods should reach Running/Ready
 kubectl logs -n omcsi <pod>  # check for startup errors
 ```
 
+### Terraform
+
+CI runs `fmt -check -diff`, `init -backend=false`, and `validate` against **all four**
+targets — `linode`, `aws`, `existing-cluster`, `hetzner` — on every PR. Because
+`terraform/modules/` is shared, editing one target can break another, so check each:
+
+```bash
+for t in linode aws existing-cluster hetzner; do
+  terraform -chdir=terraform/$t fmt -check -diff
+  terraform -chdir=terraform/$t init -backend=false
+  terraform -chdir=terraform/$t validate
+done
+```
+
 ### CI
 ```bash
 ./scripts/ci-local.sh
 ```
 
-All three must pass before a PR is ready for review.
+All of the above must pass before a PR is ready for review.
 
 ## Networking (Kubernetes)
 
@@ -127,7 +148,7 @@ The `--set-json` form is required for the `monitoring` map because `--reuse-valu
 1. Create the service directory with a `Dockerfile`.
 2. Add the service to `compose.yml` with appropriate `depends_on`, healthcheck, and volume mounts.
 3. Add any new env vars to `sample.env`.
-4. Add a Deployment, Service, and (if needed) PVC template under `helm/omcsi/templates/<service>/`.
+4. Add a Deployment, Service, and (if needed) PVC as a single flat template file `helm/omcsi/templates/<service>.yaml`, matching the sibling services — the chart has no per-service template subdirectories.
 5. Add NetworkPolicy ingress/egress rules for the new service.
 6. Expose any new config knobs in `values.yaml`.
 7. Verify both deployment targets (see Verification section above).


### PR DESCRIPTION
## Summary

Five inaccuracies across `CLAUDE.md` and `CI-DOCUMENTATION.md` are corrected. Each was verified against the source it describes.

- **Project structure table** — rows for `terraform/aws/`, `terraform/existing-cluster/`, and `terraform/modules/` are added. Only `hetzner` and `linode` were listed, yet `.github/workflows/ci.yml` runs `fmt -check -diff`, `init -backend=false`, and `validate` for all four targets, and `terraform/modules/` (`omcsi-helm`, `traefik`) is shared — so an edit confined to one target can fail CI on a target that was never documented.
- **`terraform/modules/` consumers** — the row is scoped to the three targets that actually consume the modules. `terraform/aws/helm.tf:28`, `terraform/linode/helm.tf:28`, and `terraform/existing-cluster/main.tf:22` each set `source = "../modules/omcsi-helm"`; `hetzner` references no module and instead runs `helm upgrade` over SSH (`terraform/hetzner/main.tf:183`).
- **`helm lint`** — the documented `helm lint helm/omcsi` fails as written, because `secrets.rconPassword` and `secrets.adminPassword` are wrapped in `required` in `helm/omcsi/templates/secret.yaml` and default to `""` in `values.yaml`. The invocation is brought in line with `ci.yml:164`.
- **`helm template ... --values values-override.yaml`** — `values-override.yaml` is a local, gitignored file absent from a fresh checkout, which is now stated rather than implied.
- **"Adding a New Service" step 4** — the chart uses flat `helm/omcsi/templates/<service>.yaml` files, not `helm/omcsi/templates/<service>/` subdirectories. No per-service subdirectory exists anywhere under `helm/omcsi/templates/`.

A short Terraform verification section is also added, covering all four targets, alongside the existing Docker Compose and Kubernetes/Helm sections.

The branch has been rebased onto `main` at `b9dcaeb`, which added `values-override.yaml` to `.gitignore` — the "local, gitignored file" wording above is now backed by `.gitignore:5-6` rather than by convention alone.

## Test plan

- [x] `helm/omcsi/templates/` listed recursively — flat files only, confirming the step 4 correction.
- [x] `helm/omcsi/templates/secret.yaml` lines 9 and 11 and `helm/omcsi/values.yaml` lines 317/319 read directly, confirming the `required`-on-empty-default lint failure.
- [x] `.github/workflows/ci.yml` read directly — `helm lint` invocation at line 164, and the four Terraform targets at lines 351–417.
- [x] `terraform/` listed and every target grepped for `modules/` to confirm which consume the shared modules.
- [x] Deployment-target parity is unaffected: this change is documentation only. No service, environment variable, volume, or inter-service traffic path is altered, so no accompanying edit to `compose.yml`, `sample.env`, `helm/omcsi/templates/`, `values.yaml`, or `networkpolicies.yaml` is required.
- [x] CI green on `6cd221a`: Validate Code and Configuration, Helm Unit Tests, Helm Deploy Smoke Test, Terraform Validate, Security Scanning, Trivy, Test Minecraft Server Run.

## Note on merging

`CLAUDE.md` is agent-loaded configuration, and #227 records that changes to it are expected to receive explicit human review rather than an autonomous edit. This PR is therefore left for a human to merge; it has not been self-merged, notwithstanding that this session carried a general merge pre-authorization. The work itself is complete — nothing further is pending on it.

Closes #227
Closes #238
Closes #239

<!-- gardener-tend-dispatch -->

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).