### PR TITLE
chore: release version 0.1.0-SNAPSHOT-8-8-2026

### DIFF
--- a/agent-manager/build.gradle
+++ b/agent-manager/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.openmc'
-version = '0.0.1'
+version = '0.1.0-SNAPSHOT-8-8-2026'
 
 java {
     toolchain {

--- a/alert-manager/build.gradle
+++ b/alert-manager/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.openmc'
-version = '0.0.1'
+version = '0.1.0-SNAPSHOT-8-8-2026'
 
 java {
     toolchain {

--- a/backup-manager/build.gradle
+++ b/backup-manager/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.openmc'
-version = '0.0.1'
+version = '0.1.0-SNAPSHOT-8-8-2026'
 
 java {
     toolchain {

--- a/minecraft-wrapper/build.gradle
+++ b/minecraft-wrapper/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.openmc'
-version = '0.0.1'
+version = '0.1.0-SNAPSHOT-8-8-2026'
 
 java {
     toolchain {

--- a/web-app/build.gradle
+++ b/web-app/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.openmc'
-version = '0.0.1'
+version = '0.1.0-SNAPSHOT-8-8-2026'
 
 java {
     toolchain {


### PR DESCRIPTION
## Summary

The version has been bumped from `0.0.1` to `0.1.0-SNAPSHOT-8-8-2026` in `agent-manager/build.gradle`, `alert-manager/build.gradle`, `backup-manager/build.gradle`, `minecraft-wrapper/build.gradle`, `web-app/build.gradle`.

The bump marks open-mc-server-infrastructure moving to an AI-first development approach: day-to-day feature work,
grooming, review and maintenance now run through AI agents working directly against this
repository, with the maintainers setting direction and approving what lands.

It is not a compatibility break. Behaviour, configuration and stored data are unchanged, and
existing installations can upgrade in place — the version marks a change in how the project is
built, not in what it does.

## Snapshot designation

The dated snapshot designation follows the precedent set by Medieval Factions'
`6.0.0-SNAPSHOT-7-25-2026`: the AI-first line has not yet been verified in live operation, and
the designation stays until it has.

## Notes

This is part of a garden-wide pass applying the same bump across every project tended by
Gardener. Only version metadata and the documentation that cites it has been changed; no functional code was touched.

---
*Drafted by Claude on behalf of Daniel Stephenson.*
