### PR TITLE
fix(ci): add ShellCheck, Helm, and Terraform checks to ci-local.sh

### DIFF
--- a/CI-DOCUMENTATION.md
+++ b/CI-DOCUMENTATION.md
@@ -130,6 +130,14 @@ It validates the compose file against a `mktemp` copy of `sample.env` rather tha
 `.env`, so your real credentials are left untouched. Because it now runs the test suite
 for all five Gradle modules, expect it to take several minutes on a cold Gradle cache.
 
+Alongside those, it runs ShellCheck, `helm lint`, `helm unittest`, and
+`terraform fmt -check`/`init -backend=false`/`validate` for the `linode`, `aws`,
+`existing-cluster`, and `hetzner` targets. ShellCheck, Helm, the helm-unittest
+plugin, and Terraform are optional: a check whose tool is not installed is
+skipped with a warning and repeated in the summary printed at the end of the
+run. Skipped checks are still enforced by CI, so a local run with skips is a
+weaker signal than a green pipeline.
+
 ## What Gets Checked
 
 ### ✅ Code Quality

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,12 @@ done
 ./scripts/ci-local.sh
 ```
 
+This runs all of the above in one pass — ShellCheck, `docker compose config`,
+`helm lint`, `helm unittest`, the Terraform loop for all four targets, and every
+module's Gradle tests. Any check whose tool is missing locally is skipped with a
+warning and repeated in the summary at the end, so read that summary: a skipped
+check is still enforced by CI.
+
 All of the above must pass before a PR is ready for review.
 
 ## Networking (Kubernetes)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,17 +33,25 @@ Thank you for your interest in contributing to this project! This document provi
 ## Testing
 
 ### Required Checks
-Before submitting a pull request, ensure all these checks pass:
+Before submitting a pull request, run the local CI validation script:
 
 ```bash
-# Run local CI validation
 ./scripts/ci-local.sh
+```
 
-# Test Docker configuration
-docker compose config
+It covers shell script syntax and ShellCheck linting, Docker Compose
+configuration, environment and documentation checks, `helm lint`,
+`helm unittest`, `terraform fmt`/`validate` for all four Terraform targets, and
+the Gradle test suite for every module.
 
-# Validate shell scripts
-shellcheck *.sh resources/*.sh scripts/*.sh
+ShellCheck, Helm, the [helm-unittest](https://github.com/helm-unittest/helm-unittest)
+plugin, and Terraform are optional locally: any check whose tool is missing is
+skipped with a warning and listed again in the summary the script prints at the
+end. Those checks are still enforced by CI, so installing the tools is the only
+way to catch those failures before pushing:
+
+```bash
+helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.0
 ```
 
 ### CI Pipeline

--- a/README.md
+++ b/README.md
@@ -1152,7 +1152,12 @@ Before submitting changes, you can run the same validation checks locally:
 ./scripts/ci-local.sh
 ```
 
-This will run basic validation checks that mirror the CI pipeline to catch issues early.
+This mirrors the CI pipeline to catch issues early: shell script syntax and
+ShellCheck linting, Docker Compose configuration, environment and documentation
+checks, `helm lint`, `helm unittest`, Terraform formatting and validation for
+all four targets, and the Gradle test suite for every module. Checks whose tool
+(ShellCheck, Helm, the helm-unittest plugin, Terraform) is not installed locally
+are skipped with a warning and listed in the summary at the end of the run.
 
 ### CI Pipeline Status
 

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -1,9 +1,27 @@
 #!/bin/bash
 
 # Local CI validation script
-# This script runs the same checks that the CI pipeline will run
+# This script runs the same checks that the CI pipeline will run.
+#
+# Checks that depend on an optional tool (ShellCheck, Helm, the helm-unittest
+# plugin, Terraform) are skipped with a warning when that tool is missing
+# locally, and every skip is reported again in the summary at the end. A skipped
+# check is still enforced by .github/workflows/ci.yml, so a clean local run with
+# skips is weaker than a green CI run.
 
 set -e
+
+# Names of checks that were skipped because a required tool is unavailable.
+SKIPPED_CHECKS=()
+
+have() {
+    command -v "$1" > /dev/null 2>&1
+}
+
+skip() {
+    SKIPPED_CHECKS+=("$1")
+    echo "⚠️  Skipping $1"
+}
 
 echo "🚀 Running local CI validation..."
 
@@ -15,6 +33,16 @@ bash -n rollback.sh
 bash -n trigger-backup.sh
 bash -n resources/post-create.sh
 echo "✅ Shell script syntax validation passed"
+
+echo "🔍 Linting shell scripts..."
+if have shellcheck; then
+    # Keep this file list in sync with the "Validate shell scripts" step in
+    # .github/workflows/ci.yml.
+    shellcheck up.sh down.sh upgrade.sh rollback.sh trigger-backup.sh resources/post-create.sh scripts/*.sh
+    echo "✅ ShellCheck passed"
+else
+    skip "ShellCheck (shellcheck is not installed)"
+fi
 
 echo "🐳 Checking Docker configuration..."
 # Validate against a throwaway env file rather than the repo's .env — that file
@@ -50,6 +78,42 @@ test -x trigger-backup.sh
 test -x resources/post-create.sh
 echo "✅ File permissions validation passed"
 
+echo "⎈ Linting Helm chart..."
+if have helm; then
+    # secrets.rconPassword and secrets.adminPassword are `required` in
+    # templates/secret.yaml, so they must be supplied for lint to succeed.
+    helm lint helm/omcsi --set secrets.rconPassword=ci --set secrets.adminPassword=ci
+    echo "✅ Helm chart lint passed"
+else
+    skip "helm lint (helm is not installed)"
+fi
+
+echo "⎈ Running Helm unit tests..."
+if ! have helm; then
+    skip "helm unittest (helm is not installed)"
+elif ! helm plugin list 2> /dev/null | grep -q "^unittest"; then
+    skip "helm unittest (the helm-unittest plugin is not installed — install it with: helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.0)"
+else
+    helm unittest helm/omcsi
+    echo "✅ Helm unit tests passed"
+fi
+
+echo "🏗️ Validating Terraform configurations..."
+if have terraform; then
+    # Every target the terraform-validate job in .github/workflows/ci.yml
+    # checks. terraform/modules/ is shared by linode, aws and existing-cluster,
+    # so editing one target can break another — all four are always validated.
+    for target in linode aws existing-cluster hetzner; do
+        echo "  🔍 ${target}..."
+        terraform -chdir="terraform/${target}" fmt -check -diff
+        terraform -chdir="terraform/${target}" init -backend=false > /dev/null
+        terraform -chdir="terraform/${target}" validate
+    done
+    echo "✅ Terraform validation passed"
+else
+    skip "Terraform fmt/init/validate (terraform is not installed)"
+fi
+
 # Every Gradle module the CI pipeline tests. Keep this list in sync with the
 # "Run <module> tests" steps in .github/workflows/ci.yml.
 for module in web-app minecraft-wrapper agent-manager alert-manager backup-manager; do
@@ -58,4 +122,12 @@ for module in web-app minecraft-wrapper agent-manager alert-manager backup-manag
     echo "✅ ${module} tests passed"
 done
 
-echo "🎉 All local CI checks passed!"
+if [ ${#SKIPPED_CHECKS[@]} -eq 0 ]; then
+    echo "🎉 All local CI checks passed!"
+else
+    echo "🎉 All local CI checks that could be run passed, but ${#SKIPPED_CHECKS[@]} were skipped:"
+    for check in "${SKIPPED_CHECKS[@]}"; do
+        echo "  ⚠️  ${check}"
+    done
+    echo "These are still enforced by CI — install the missing tools to catch failures before pushing."
+fi


### PR DESCRIPTION
## Summary

- ShellCheck linting, `helm lint`, `helm unittest`, and the Terraform `fmt -check -diff` / `init -backend=false` / `validate` loop over all four targets (`linode`, `aws`, `existing-cluster`, `hetzner`) have been added to `scripts/ci-local.sh`, closing the gap between what the script claims to run and what `.github/workflows/ci.yml` actually enforces.
- Each added check is guarded on tool availability. When `shellcheck`, `helm`, the `helm-unittest` plugin, or `terraform` is not installed locally, the check is skipped with a warning rather than failing the run.
- Every skip is collected and repeated in a summary printed at the end of the run, so a local pass with skips is visibly distinguishable from a full pass. The summary states that skipped checks are still enforced by CI.
- The ShellCheck file list and the Terraform target list are kept in sync with the corresponding CI steps, and comments in the script point at those steps.
- Documentation has been brought back in line with the script's behaviour in `README.md`, `CONTRIBUTING.md`, `CI-DOCUMENTATION.md`, and `CLAUDE.md`. The now-redundant standalone `docker compose config` and `shellcheck` steps have been removed from the `CONTRIBUTING.md` required-checks block, replaced by a description of what the single script covers plus the `helm plugin install` command needed for `helm unittest`.

No service, container, or infrastructure behaviour is changed by this PR — only the local validation script and the documents describing it — so the Docker/Kubernetes parity rule is not engaged.

## Test plan

- [x] `scripts/ci-local.sh` was reviewed line by line against `.github/workflows/ci.yml` for check-for-check parity
- [ ] `bash -n scripts/ci-local.sh` — not runnable in the dispatch environment used to prepare this change; the `Validate shell scripts` CI step covers it
- [ ] `shellcheck ... scripts/*.sh` — not runnable in the dispatch environment; the `Validate shell scripts` CI step covers it, and it now lints the modified script itself
- [ ] `helm lint` / `helm unittest` — no chart files were touched; the `Lint Helm chart` and `Helm Unit Tests` CI jobs cover them
- [ ] `terraform fmt`/`validate` — no Terraform files were touched; the `Terraform Validate` CI job covers all four targets
- [ ] Gradle module tests — no module source was touched; the CI `validate` job covers them

Closes #242

<!-- gardener-tend-dispatch -->

_This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener)._