### PR TITLE
fix(minecraft-wrapper): decode server logs leniently and extract the tail read

### DIFF
--- a/minecraft-wrapper/src/main/java/com/openmc/minecraftwrapper/service/MinecraftServerService.java
+++ b/minecraft-wrapper/src/main/java/com/openmc/minecraftwrapper/service/MinecraftServerService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -54,6 +55,9 @@ public class MinecraftServerService {
     private final AtomicReference<TpsCache> tpsCacheRef =
             new AtomicReference<>(new TpsCache(null, Instant.EPOCH));
     private static final Duration TPS_CACHE_TTL = Duration.ofSeconds(30);
+
+    /** Number of trailing log lines scanned for a Paper/Spigot TPS reading. */
+    private static final int TPS_SCAN_LINES = 500;
 
     public MinecraftServerService(AlertService alertService, ShutdownService shutdownService) {
         this.alertService = alertService;
@@ -397,19 +401,37 @@ public class MinecraftServerService {
      * @return tail of the log file, oldest line first
      */
     public List<String> getRecentLogLines(int maxLines) {
+        return readLogTail(maxLines);
+    }
+
+    /**
+     * Read the last {@code maxLines} lines of {@code logs/latest.log} into a list, oldest first.
+     *
+     * <p>Uses a streaming bounded deque so the whole file is never held in memory, and decodes
+     * leniently: {@link InputStreamReader} constructed with a {@link java.nio.charset.Charset}
+     * replaces undecodable bytes with U+FFFD instead of throwing. Server logs regularly carry
+     * bytes that are not valid UTF-8 (plugin output, player chat), and a strict decoder would
+     * abort the read mid-stream with an {@link UncheckedIOException} and lose the entire tail.
+     *
+     * @param maxLines maximum number of lines to return
+     * @return tail of the log file, oldest line first; empty when the file is missing or unreadable
+     */
+    private List<String> readLogTail(int maxLines) {
         Path logFile = Path.of(serverDirectory, "logs", "latest.log");
         if (!Files.exists(logFile)) {
             log.debug("Server log file not found at {}", logFile);
             return List.of();
         }
-        Deque<String> tail = new ArrayDeque<>(maxLines);
-        try (var lines = Files.lines(logFile)) {
-            lines.forEach(line -> {
+        Deque<String> tail = new ArrayDeque<>(Math.max(1, maxLines));
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(Files.newInputStream(logFile), StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
                 tail.addLast(line);
                 if (tail.size() > maxLines) {
                     tail.pollFirst();
                 }
-            });
+            }
             return new ArrayList<>(tail);
         } catch (IOException e) {
             log.error("Failed to read server log file {}: {}", logFile, e.getMessage());
@@ -499,9 +521,12 @@ public class MinecraftServerService {
     }
 
     /**
-     * Scan the last 500 lines of {@code logs/latest.log} for a Paper/Spigot TPS line.
+     * Scan the tail of {@code logs/latest.log} for a Paper/Spigot TPS line.
      *
-     * <p>Uses a streaming approach to avoid loading the entire log file into memory.
+     * <p>Reads through {@link #readLogTail(int)}, so the full file is never held in memory and an
+     * unreadable log yields {@code null} rather than an exception. A missing TPS line and an
+     * unreadable log are both cached for {@link #TPS_CACHE_TTL} so the file is not re-scanned on
+     * every metrics request.
      *
      * @return the TPS segment starting from "TPS from last …", or {@code null} if not found
      */
@@ -511,30 +536,13 @@ public class MinecraftServerService {
         if (Duration.between(cached.fetchedAt(), Instant.now()).compareTo(TPS_CACHE_TTL) < 0) {
             return cached.tps();
         }
-        Path logFile = Path.of(serverDirectory, "logs", "latest.log");
-        if (!Files.exists(logFile)) {
-            tpsCacheRef.set(new TpsCache(null, Instant.now()));
-            return null;
-        }
-        // Collect the last 500 lines into a bounded deque to avoid loading the full file
-        Deque<String> tail = new ArrayDeque<>(500);
-        try (var lines = Files.lines(logFile)) {
-            lines.forEach(line -> {
-                tail.addLast(line);
-                if (tail.size() > 500) {
-                    tail.pollFirst();
-                }
-            });
-        } catch (IOException e) {
-            log.debug("Could not read server log for TPS: {}", e.getMessage());
-            return null;
-        }
+        // Collect the last 500 lines to avoid loading the full file
+        List<String> tail = readLogTail(TPS_SCAN_LINES);
         // Scan backwards through the tail for the most recent TPS entry
-        String[] tailArr = tail.toArray(new String[0]);
-        for (int i = tailArr.length - 1; i >= 0; i--) {
-            int idx = tailArr[i].indexOf("TPS from last");
+        for (int i = tail.size() - 1; i >= 0; i--) {
+            int idx = tail.get(i).indexOf("TPS from last");
             if (idx >= 0) {
-                String result = tailArr[i].substring(idx);
+                String result = tail.get(i).substring(idx);
                 tpsCacheRef.set(new TpsCache(result, Instant.now()));
                 return result;
             }

--- a/minecraft-wrapper/src/main/java/com/openmc/minecraftwrapper/service/MinecraftServerService.java
+++ b/minecraft-wrapper/src/main/java/com/openmc/minecraftwrapper/service/MinecraftServerService.java
@@ -395,7 +395,9 @@ public class MinecraftServerService {
      * Returns an empty list if the log file does not exist or cannot be read.
      *
      * <p>Uses a streaming bounded-deque to avoid loading the entire log file into memory,
-     * regardless of how large the file has grown.
+     * regardless of how large the file has grown. Decoding is lenient, so a line containing
+     * bytes that are not valid UTF-8 is returned with those bytes replaced by U+FFFD rather
+     * than costing the caller the whole tail — see {@link #readLogTail(int)}.
      *
      * @param maxLines maximum number of lines to return (clamped to 1..logsDiagnosticMaxLines by the caller)
      * @return tail of the log file, oldest line first
@@ -422,6 +424,8 @@ public class MinecraftServerService {
             log.debug("Server log file not found at {}", logFile);
             return List.of();
         }
+        // Math.max only keeps the initial capacity legal; a non-positive maxLines still yields an
+        // empty list, because every line added below is evicted again on the same iteration.
         Deque<String> tail = new ArrayDeque<>(Math.max(1, maxLines));
         try (BufferedReader reader = new BufferedReader(
                 new InputStreamReader(Files.newInputStream(logFile), StandardCharsets.UTF_8))) {

--- a/minecraft-wrapper/src/test/java/com/openmc/minecraftwrapper/service/MinecraftServerServiceTest.java
+++ b/minecraft-wrapper/src/test/java/com/openmc/minecraftwrapper/service/MinecraftServerServiceTest.java
@@ -1,0 +1,182 @@
+package com.openmc.minecraftwrapper.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MinecraftServerService Tests")
+class MinecraftServerServiceTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Mock
+    private AlertService alertService;
+
+    @Mock
+    private ShutdownService shutdownService;
+
+    private MinecraftServerService service;
+    private Path logFile;
+
+    @BeforeEach
+    void setUp() {
+        service = new MinecraftServerService(alertService, shutdownService);
+        ReflectionTestUtils.setField(service, "serverDirectory", tempDir.toString());
+        logFile = tempDir.resolve("logs").resolve("latest.log");
+    }
+
+    // ── Log helpers ──────────────────────────────────────────────────────────
+
+    /** Write the supplied lines to {@code logs/latest.log} as UTF-8. */
+    private void writeLog(String... lines) throws IOException {
+        Files.createDirectories(logFile.getParent());
+        Files.writeString(logFile, String.join("\n", lines) + "\n", StandardCharsets.UTF_8);
+    }
+
+    /** Write raw bytes to {@code logs/latest.log}, bypassing any charset encoding. */
+    private void writeLogBytes(byte[] bytes) throws IOException {
+        Files.createDirectories(logFile.getParent());
+        try (OutputStream out = Files.newOutputStream(logFile)) {
+            out.write(bytes);
+        }
+    }
+
+    /** Invoke the private TPS parser directly — the public path requires a live server process. */
+    private String parseTps() {
+        return ReflectionTestUtils.invokeMethod(service, "parseTpsFromLogs");
+    }
+
+    @Nested
+    @DisplayName("getRecentLogLines")
+    class GetRecentLogLines {
+
+        @Test
+        @DisplayName("returns an empty list when the log file does not exist")
+        void returnsEmptyListWhenLogMissing() {
+            assertTrue(service.getRecentLogLines(10).isEmpty());
+        }
+
+        @Test
+        @DisplayName("returns every line, oldest first, when the file is shorter than maxLines")
+        void returnsAllLinesWhenFileIsShort() throws IOException {
+            writeLog("first", "second", "third");
+
+            assertEquals(List.of("first", "second", "third"), service.getRecentLogLines(10));
+        }
+
+        @Test
+        @DisplayName("returns only the trailing maxLines lines, oldest first")
+        void returnsTailOnly() throws IOException {
+            writeLog("one", "two", "three", "four", "five");
+
+            assertEquals(List.of("four", "five"), service.getRecentLogLines(2));
+        }
+
+        @Test
+        @DisplayName("returns an empty list when maxLines is zero")
+        void returnsEmptyListForZeroMaxLines() throws IOException {
+            writeLog("one", "two");
+
+            assertTrue(service.getRecentLogLines(0).isEmpty());
+        }
+
+        @Test
+        @DisplayName("replaces undecodable bytes instead of throwing (issue #245)")
+        void survivesNonUtf8Bytes() throws IOException {
+            // 0xFF is not valid UTF-8; a strict decoder throws MalformedInputException here
+            writeLogBytes(new byte[]{'o', 'k', '\n', (byte) 0xFF, '\n', 'l', 'a', 's', 't', '\n'});
+
+            List<String> lines = assertDoesNotThrow(() -> service.getRecentLogLines(10));
+
+            assertEquals(3, lines.size());
+            assertEquals("ok", lines.get(0));
+            assertEquals("�", lines.get(1));
+            assertEquals("last", lines.get(2));
+        }
+    }
+
+    @Nested
+    @DisplayName("parseTpsFromLogs")
+    class ParseTpsFromLogs {
+
+        @Test
+        @DisplayName("returns null when the log file does not exist")
+        void returnsNullWhenLogMissing() {
+            assertNull(parseTps());
+        }
+
+        @Test
+        @DisplayName("returns null when no TPS line is present")
+        void returnsNullWhenNoTpsLine() throws IOException {
+            writeLog("[12:00:00 INFO]: Done (1.234s)!", "[12:00:01 INFO]: Player joined");
+
+            assertNull(parseTps());
+        }
+
+        @Test
+        @DisplayName("returns the TPS segment from the most recent matching line")
+        void returnsMostRecentTpsSegment() throws IOException {
+            writeLog(
+                    "[12:00:00 INFO]: TPS from last 1m, 5m, 15m: 15.00, 15.00, 15.00",
+                    "[12:00:01 INFO]: Player joined",
+                    "[12:00:02 INFO]: TPS from last 1m, 5m, 15m: 20.00, 19.50, 19.00");
+
+            assertEquals("TPS from last 1m, 5m, 15m: 20.00, 19.50, 19.00", parseTps());
+        }
+
+        @Test
+        @DisplayName("finds a TPS line that is undecodable elsewhere in the log (issue #245)")
+        void survivesNonUtf8Bytes() throws IOException {
+            byte[] prefix = "[12:00:00 INFO]: ".getBytes(StandardCharsets.UTF_8);
+            byte[] suffix = "\n[12:00:01 INFO]: TPS from last 1m, 5m, 15m: 20.00, 19.50, 19.00\n"
+                    .getBytes(StandardCharsets.UTF_8);
+            byte[] bytes = new byte[prefix.length + 1 + suffix.length];
+            System.arraycopy(prefix, 0, bytes, 0, prefix.length);
+            bytes[prefix.length] = (byte) 0xFF;
+            System.arraycopy(suffix, 0, bytes, prefix.length + 1, suffix.length);
+            writeLogBytes(bytes);
+
+            assertEquals("TPS from last 1m, 5m, 15m: 20.00, 19.50, 19.00",
+                    assertDoesNotThrow(MinecraftServerServiceTest.this::parseTps));
+        }
+
+        @Test
+        @DisplayName("serves the cached reading rather than re-scanning within the TTL")
+        void cachesTheParsedReading() throws IOException {
+            writeLog("[12:00:00 INFO]: TPS from last 1m, 5m, 15m: 20.00, 19.50, 19.00");
+            String first = parseTps();
+
+            writeLog("[12:01:00 INFO]: TPS from last 1m, 5m, 15m: 5.00, 6.00, 7.00");
+
+            assertEquals(first, parseTps());
+        }
+
+        @Test
+        @DisplayName("caches a missing reading so the log is not re-scanned within the TTL")
+        void cachesTheAbsenceOfAReading() throws IOException {
+            writeLog("[12:00:00 INFO]: Done (1.234s)!");
+            assertNull(parseTps());
+
+            writeLog("[12:01:00 INFO]: TPS from last 1m, 5m, 15m: 20.00, 19.50, 19.00");
+
+            assertNull(parseTps());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Both log-reading paths in `MinecraftServerService` decoded `logs/latest.log` with `Files.lines(...)`, whose strict UTF-8 decoder throws `UncheckedIOException` (wrapping `MalformedInputException`) on any byte that is not valid UTF-8. Being unchecked, that exception was not caught by the `catch (IOException e)` blocks both methods already had, and it escaped to the REST layer — so `GET /api/server/logs` and `GET /api/server/metrics` both returned HTTP 500 over a single undecodable byte written by plugin output or player chat.
- The duplicated bounded-deque tail read has been extracted into a single private `readLogTail(int)`, which reads through an `InputStreamReader` constructed with a `Charset`. That constructor applies `CodingErrorAction.REPLACE`, so undecodable bytes become U+FFFD and the tail is preserved instead of discarded.
- `parseTpsFromLogs()` now delegates to `readLogTail(TPS_SCAN_LINES)`, and an unreadable log is cached for the TTL exactly as a missing TPS line already was, so a broken log is not re-scanned on every metrics request.
- The magic `500` scan depth has been named `TPS_SCAN_LINES`.
- `MinecraftServerServiceTest` has been added — the class previously had no test coverage at all — covering the tail read (missing file, short file, truncation to `maxLines`, zero `maxLines`), the TPS parse (missing file, no match, most-recent match wins), the TPS cache (both a found and an absent reading), and the non-UTF-8 regression on both paths.

## Test plan

- [x] `./gradlew test` in `minecraft-wrapper` — 120 tests pass, 11 of them new; both regression tests fail against the previous implementation with `UncheckedIOException`.
- [x] No deployment-target parity work is implied: the change is Java-only and the same image is shipped to both Docker Compose and Kubernetes. No `compose.yml`, `sample.env`, Helm template/value, or NetworkPolicy change is required, and no new environment variable is read.
- [x] No shell script, Helm chart, or Terraform file is touched, so ShellCheck, `helm lint`/`helm unittest`, and the four-target Terraform loop are unaffected; all remain enforced by CI on this PR.

Closes #245

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

<!-- gardener-tend-dispatch -->